### PR TITLE
Integrating gen_counts.R.

### DIFF
--- a/regtest.sh
+++ b/regtest.sh
@@ -117,8 +117,8 @@ _run-one-case() {
   # Save the "spec" for showing in the summary.
   echo "$@" > $case_dir/spec.txt
 
-  #local fast_counts=F
   local fast_counts=T
+  # local fast_counts=T
 
   if test $fast_counts = T; then
     # Print params CSV.  No JSON.
@@ -170,7 +170,7 @@ _run-one-case() {
 
     analysis/tools/sum_bits.py \
       $case_dir/case_params.csv \
-      < $case_dir/out.csv \
+      < $case_dir/case_out.csv \
       > $case_dir/case_counts.csv
   fi
 

--- a/tests/analyze.R
+++ b/tests/analyze.R
@@ -24,7 +24,7 @@
 library(optparse)
 
 # For unit tests
-is_main <- (length(sys.frames) == 0)
+is_main <- (length(sys.frames()) == 0)
 
 # Do command line parsing first to catch errors.  Loading libraries in R is
 # slow.

--- a/tests/gen_counts.R
+++ b/tests/gen_counts.R
@@ -1,3 +1,5 @@
+#!/usr/bin/env Rscript
+#
 # Copyright 2015 Google Inc. All rights reserved.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-RandomPartition <- function(total, weights){
+source('analysis/R/read_input.R')
+
+RandomPartition <- function(total, weights) {
   # Outputs a random partition according to a specified distribution
   # Args:
   #   total - number of balls
@@ -25,7 +29,7 @@ RandomPartition <- function(total, weights){
   bins <- length(weights)
 
   if (total == 0) {
-    result = rep(0, bins)
+    result <- rep(0, bins)
   } else {
     if (any(weights < 0))
       stop("Weights cannot be negative")
@@ -34,7 +38,7 @@ RandomPartition <- function(total, weights){
       stop("Weights cannot sum up to 0")
       
     # idiomatic way:
-    #   rnd_list = sample(strs, total, replace = TRUE, weights)
+    #   rnd_list <- sample(strs, total, replace = TRUE, weights)
     #   apply(as.array(strs), 1, function(x) length(rnd_list[rnd_list == x]))
     #
     # The following is much faster for larger totals. We can replace a loop with
@@ -61,10 +65,13 @@ RandomPartition <- function(total, weights){
   result
 }
 
-GenerateCounts <- function(params, total, true_map, weights = NULL){
+GenerateCounts <- function(params, true_map, partition) {
   # Fast simulation of the marginal table for RAPPOR reports 
   # Args:
   #   params - parameters of the RAPPOR reporting process 
+  #   total - number of reports
+  #   true_map - hashed true inputs
+  #   weights - vector encoding the probability that a ball lands into a bin
   if (nrow(true_map$map) != (params$m * params$k)) {
     stop(cat("Map does not match the params file!",
                  "mk =", params$m * params$k,
@@ -72,23 +79,10 @@ GenerateCounts <- function(params, total, true_map, weights = NULL){
                  sep = " "))
   }
   
-  if(is.null(weights))
-    weights <- rep(1, length(true_map$strs))  # uniform by default
-  
-  if (length(true_map$strs) != length(weights)) {
-    stop(cat("Dimensions of weights do not match:",
-              "m =", length(true_map$strs), "weights col:", length(weights),
-              sep = " "))
-  }
-  
-  # Computes the number of clients reporting each string 
-  # according to the pre-specified distribution.
-  actual <- RandomPartition(total, weights)
-  
   # For each reporting type computes its allocation to cohorts.  
   # Output is an m x strs matrix.
   cohorts <- as.matrix(
-                apply(as.data.frame(actual), 1, 
+                apply(as.data.frame(partition), 1, 
                       function(count) RandomPartition(count, rep(1, params$m))))
   
   # Expands to (m x k) x strs matrix, where each element (corresponding to the 
@@ -116,6 +110,77 @@ GenerateCounts <- function(params, total, true_map, weights = NULL){
     unlist(lapply(counts_zeros, 
                   function(x) rbinom(n = 1, size = x, prob = qstar)))
   
-  cbind(apply(cohorts, 1, sum),
+  counts <- cbind(apply(cohorts, 1, sum),
         matrix(reported_ones, nrow = params$m, ncol = params$k, byrow = TRUE))
+
+  counts
+}
+
+# Usage:
+#
+# $ ./gen_counts.R foo_params.csv foo_true_map.csv exp 10000 \
+#                  foo_counts.csv
+#
+# 4 inputs and 1 output.
+
+main <- function(argv) {
+  params_file <- argv[[1]]
+  true_map_file <- argv[[2]]
+  dist <- argv[[3]]
+  num_reports <- as.integer(argv[[4]])
+  out_prefix <- argv[[5]]
+
+  params <- ReadParameterFile(params_file)
+
+  true_map <- ReadMapFile(true_map_file)
+  print(true_map$strs)
+
+  # These are the three distributions in gen_sim_input.py
+  if (dist == 'exp') {
+    weights <- c()
+  } else if (dist == 'gauss') {
+    weights <- c()
+  } else if (dist == 'unif') {
+    weights <- rep(1, length(true_map$strs))  # ones vector
+  } else {
+    stop(sprintf("Invalid distribution '%s'", dist))
+  }
+
+  str(params)
+
+  if (length(true_map$strs) != length(weights)) {
+    stop(cat("Dimensions of weights do not match:",
+              "m =", length(true_map$strs), "weights col:", length(weights),
+              sep = " "))
+  }
+
+  # Computes the number of clients reporting each string 
+  # according to the pre-specified distribution.
+  partition <- RandomPartition(num_reports, weights)
+  print('PARTITION')
+  print(partition)
+
+  # Histogram
+  true_hist <- data.frame(string = true_map$strs, count = partition)
+
+  counts <- GenerateCounts(params, true_map, partition)
+
+  # Now create a CSV file
+
+  # Opposite of ReadCountsFile in read_input.R
+  # http://stackoverflow.com/questions/6750546/export-csv-without-col-names
+  counts_path <- paste0(out_prefix, '_counts.csv')
+  write.table(counts, file = counts_path,
+              row.names = FALSE, col.names = FALSE, sep = ',')
+  cat(sprintf('Wrote %s\n', counts_path))
+
+  # TODO: Don't write strings that appear 0 times?
+
+  hist_path <- paste0(out_prefix, '_hist.csv')
+  write.csv(true_hist, file = hist_path, row.names = FALSE)
+  cat(sprintf('Wrote %s\n', hist_path))
+}
+
+if (length(sys.frames()) == 0) {
+  main(commandArgs(TRUE))
 }

--- a/tests/gen_counts.R
+++ b/tests/gen_counts.R
@@ -101,8 +101,8 @@ GenerateCounts <- function(params, true_map, partition) {
 
   # probability that a true 1 is reported as "1"
   pstar <- (1 - f / 2) * q + (f / 2) * p
-  # probability that a true 0 is reported as "0"
-  qstar <- (1 - f / 2) * (1 - p) + (f / 2) * (1 - q)
+  # probability that a true 0 is reported as "1"
+  qstar <- (1 - f / 2) * p + (f / 2) * q
   
   reported_ones <- 
     unlist(lapply(counts_ones, 
@@ -133,7 +133,7 @@ main <- function(argv) {
   params <- ReadParameterFile(params_file)
 
   true_map <- ReadMapFile(true_map_file)
-  print(true_map$strs)
+  # print(true_map$strs)
 
   # These are the three distributions in gen_sim_input.py
   if (dist == 'exp') {


### PR DESCRIPTION
- Make it run as a script.  Add a main(), which reads the params and
  true map, and writes out the counts file and the true histogram.
- Fix bug in analyze.R introduced in the last change.  main() wasn't
  running because of sys.frames vs sys.frames()
- Get rid of unused HTML output in gen_sim_input.py and rappor_sim.py
  (replaced by regtest.html)
- gen_sim_input writes to stdout.
- rappor_sim.p uses --out-prefix, and other simplifications
- Separate the RandomPartition and GenerateCounts functions so we can
  print the true histogram as well as the counts
- regtest.sh has an alternate path for gen_counts.R