### PR TITLE
Fixing fast partition for exp, gauss

### DIFF
--- a/tests/gen_counts.R
+++ b/tests/gen_counts.R
@@ -35,21 +35,21 @@ RandomPartition <- function(total, weights) {
   bins <- length(weights)
   result <- rep(0, bins)
   
-  if (total > 0) {  # if total == 0, nothing else to do  
-    # idiomatic way:
-    #   rnd_list <- sample(strs, total, replace = TRUE, weights)
-    #   apply(as.array(strs), 1, function(x) length(rnd_list[rnd_list == x]))
-    #
-    # The following is much faster for larger totals. We can replace a loop with
-    # (tail) recusion, but R chokes with the recursion depth > 850.
-    
-    w <- sum(weights)
+  # idiomatic way:
+  #   rnd_list <- sample(strs, total, replace = TRUE, weights)
+  #   apply(as.array(strs), 1, function(x) length(rnd_list[rnd_list == x]))
+  #
+  # The following is much faster for larger totals. We can replace a loop with
+  # (tail) recusion, but R chokes with the recursion depth > 850.
+  
+  w <- sum(weights)
 
-    for (i in 1:bins) {
+  for (i in 1:bins) 
+    if (total > 0) {  # if total == 0, nothing else to do  
       # invariant: w = sum(weights[i:bins]) 
       # rather than computing sum every time leading to quadratic time, keep 
       # updating it
-
+  
       # The probability p is clamped to [0, 1] to avoid under/overflow errors.
       p <- min(max(weights[i] / w, 0), 1) 
       # draw the number of balls falling into the current bin
@@ -57,9 +57,8 @@ RandomPartition <- function(total, weights) {
       result[i] <- rnd_draw  # push rnd_draw balls from total to result[i]
       total <- total - rnd_draw
       w <- w - weights[i]  
-    }
   }
-  
+
   return(result)
 }
 

--- a/tests/gen_counts.R
+++ b/tests/gen_counts.R
@@ -26,17 +26,16 @@ RandomPartition <- function(total, weights) {
   # Example:
   #   > RandomPartition(100, c(3, 2, 1, 0, 1))
   #   [1] 47 24 15  0 14
+  if (any(weights < 0))
+    stop("Weights cannot be negative")
+  
+  if (sum(weights) == 0)
+    stop("Weights cannot sum up to 0")
+  
   bins <- length(weights)
-
-  if (total == 0) {
-    result <- rep(0, bins)
-  } else {
-    if (any(weights < 0))
-      stop("Weights cannot be negative")
-    
-    if (sum(weights) == 0)
-      stop("Weights cannot sum up to 0")
-      
+  result <- rep(0, bins)
+  
+  if (total > 0) {  # if total == 0, nothing else to do  
     # idiomatic way:
     #   rnd_list <- sample(strs, total, replace = TRUE, weights)
     #   apply(as.array(strs), 1, function(x) length(rnd_list[rnd_list == x]))
@@ -44,25 +43,24 @@ RandomPartition <- function(total, weights) {
     # The following is much faster for larger totals. We can replace a loop with
     # (tail) recusion, but R chokes with the recursion depth > 850.
     
-    result <- vector(length = bins)
     w <- sum(weights)
 
     for (i in 1:bins) {
       # invariant: w = sum(weights[i:bins]) 
       # rather than computing sum every time leading to quadratic time, keep 
       # updating it
-      if (w > 0) {
-        p <- weights[i] / w
-        # draw the number of balls falling into the current bin
-        rnd_draw <- rbinom(n = 1, size = total, prob = p)
-        result[i] <- rnd_draw  # push rnd_draw balls from total to result[i]
-        total <- total - rnd_draw
-        w <- w - weights[i]  
-      }
+
+      # The probability p is clamped to [0, 1] to avoid under/overflow errors.
+      p <- min(max(weights[i] / w, 0), 1) 
+      # draw the number of balls falling into the current bin
+      rnd_draw <- rbinom(n = 1, size = total, prob = p)
+      result[i] <- rnd_draw  # push rnd_draw balls from total to result[i]
+      total <- total - rnd_draw
+      w <- w - weights[i]  
     }
   }
   
-  result
+  return(result)
 }
 
 GenerateCounts <- function(params, true_map, partition) {
@@ -140,21 +138,15 @@ main <- function(argv) {
   # These are the three distributions in gen_sim_input.py
   if (dist == 'exp') {
     # NOTE: gen_sim_input.py hard-codes lambda = N/5 for 'exp'
-    weights <- dexp(1:num_unique_values, rate = num_unique_values / 5)
+    weights <- dexp(1:num_unique_values, rate = 5 / num_unique_values)
   } else if (dist == 'gauss') {
     # NOTE: gen_sim_input.py hard-codes stddev = N/6 for 'exp'
-    #half <- num_unique_values / 2
-    #left <- -half + 1
-    #weights <- dnorm(left : half, sd = num_unique_values / 6)
-
-    # I think the above should work, but it doesn't.  Stub it out with unif.
-    weights <- rep(1, num_unique_values)
+    half <- num_unique_values / 2
+    left <- -half + 1
+    weights <- dnorm(left : half, sd = num_unique_values / 6)  
   } else if (dist == 'unif') {
     # e.g. for N = 4, weights are [0.25, 0.25, 0.25, 0.25]
-    #weights <- dunif(1:num_unique_values, max = num_unique_values)
-
-    # I think the above should work, but it doesn't.  Stub it out with unif.
-    weights <- rep(1, num_unique_values)
+    weights <- dunif(1:num_unique_values, max = num_unique_values)
   } else {
     stop(sprintf("Invalid distribution '%s'", dist))
   }

--- a/tests/gen_counts_test.R
+++ b/tests/gen_counts_test.R
@@ -18,10 +18,10 @@ library(RUnit)
 
 source('tests/gen_counts.R')
 
-TestProcessAll <- function() {
+TestRandomPartition <- function() {
   
-  p1 <- RandomPartition(total = 100, dexp(1:1000, rate = 5 / 1000))
-  p2 <- RandomPartition(total = 1000, dnorm(1:1000, sd = 1000 / 6))
+  p1 <- RandomPartition(total = 100, dgeom(0:999, prob = .1))
+  p2 <- RandomPartition(total = 1000, dnorm(1:1000, mean = 500, sd = 1000 / 6))
   p3 <- RandomPartition(total = 10000, dunif(1:1000))
   
   # Totals must check out.
@@ -30,23 +30,20 @@ TestProcessAll <- function() {
   checkEqualsNumeric(10000, sum(p3))  
   
   # Initialize the weights vector to 1 0 1 0 1 0 ...
-  weights <- rep(1, 200)
-  even_indices <- 1:100 * 2
-  odd_indices <- even_indices - 1
-  weights[even_indices] <- 0
+  weights <- rep(c(1, 0), 100)
   
   p4 <- RandomPartition(total = 10000, weights)
   
-  # Check that zero weights don't get any mass.
-  checkEqualsNumeric(10000, sum(p4[odd_indices]))
-  checkTrue(all(p4[even_indices] == 0))
+  # Check that all mass is allocated to non-zero weights.
+  checkEqualsNumeric(10000, sum(p4[weights == 1]))
+  checkTrue(all(p4[weights == 0] == 0))
 
   p5 <- RandomPartition(total = 1000000, c(1, 2, 3, 4))
   p.value <- chisq.test(p5, p = c(.1, .2, .3, .4))$p.value
   
   # Apply the chi squared test and fail if p.value is too high or too low.
-  # Probability if failure is 2 * 1E-9, which should never happen.
+  # Probability of failure is 2 * 1E-9, which should never happen.
   checkTrue((p.value > 1E-9) && (p.value <  1 - 1E-9))
 }
 
-TestProcessAll()
+TestRandomPartition()

--- a/tests/gen_counts_test.R
+++ b/tests/gen_counts_test.R
@@ -1,0 +1,52 @@
+#!/usr/bin/env Rscript
+#
+# Copyright 2014 Google Inc. All rights reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+library(RUnit)
+
+source('tests/gen_counts.R')
+
+TestProcessAll <- function() {
+  
+  p1 <- RandomPartition(total = 100, dexp(1:1000, rate = 5 / 1000))
+  p2 <- RandomPartition(total = 1000, dnorm(1:1000, sd = 1000 / 6))
+  p3 <- RandomPartition(total = 10000, dunif(1:1000))
+  
+  # Totals must check out.
+  checkEqualsNumeric(100, sum(p1))
+  checkEqualsNumeric(1000, sum(p2))
+  checkEqualsNumeric(10000, sum(p3))  
+  
+  # Initialize the weights vector to 1 0 1 0 1 0 ...
+  weights <- rep(1, 200)
+  even_indices <- 1:100 * 2
+  odd_indices <- even_indices - 1
+  weights[even_indices] <- 0
+  
+  p4 <- RandomPartition(total = 10000, weights)
+  
+  # Check that zero weights don't get any mass.
+  checkEqualsNumeric(10000, sum(p4[odd_indices]))
+  checkTrue(all(p4[even_indices] == 0))
+
+  p5 <- RandomPartition(total = 1000000, c(1, 2, 3, 4))
+  p.value <- chisq.test(p5, p = c(.1, .2, .3, .4))$p.value
+  
+  # Apply the chi squared test and fail if p.value is too high or too low.
+  # Probability if failure is 2 * 1E-9, which should never happen.
+  checkTrue((p.value > 1E-9) && (p.value <  1 - 1E-9))
+}
+
+TestProcessAll()


### PR DESCRIPTION
Two bug fixes: (1) clamping p to be in [0,1] interval (can be outside due to floating-point underflow/overflow effects; (2) changing the dexp() rate parameter to be lambda rather than lambda inverse. Other changes are cosmetic.