### PR TITLE
Optimization of association analysis.  Command line interface.  Bug fixes.  Code cleanup.

### DIFF
--- a/analysis/R/association.R
+++ b/analysis/R/association.R
@@ -109,12 +109,13 @@ GetCondProb <- function(report, pstar, qstar, bit_indices, prob_other = NULL) {
   # Probabilities are estimated for all truth values.
   #
   # Args:
-  #   report: a single observed RAPPOR report (binary vector of length k)
-  #   params: System parameters
-  #   bit_indices: list of integer vectors of length h, specifying which bits
-  #   are set
+  #   report: A single observed RAPPOR report (binary vector of length k).
+  #   params: RAPPOR parameters.
+  #   bit_indices: list with one entry for each candidate.  Each entry is an
+  #     integer vector of length h, specifying which bits are set for the
+  #     candidate in the report's cohort.
   #   prob_other: vector of length k, indicating how often each bit in the
-  #       Bloom filter was set by a string in the "other" category
+  #     Bloom filter was set by a string in the "other" category.
   #
   # Returns:
   #   Conditional probability of report given each of the strings in
@@ -320,9 +321,9 @@ ComputeDistributionEM <- function(reports, report_cohorts, maps,
   #   ignore_other: A boolean describing whether to compute the "other" category
   #   params: RAPPOR encoding parameters.  If set, all variables are assumed to
   #       be encoded with these parameters.
-  #   params_list: A list of RAPPOR encoding parameters (each of which are
-  #       lists).  If set, it must be the same length as 'reports' (one entry
-  #       per dimension)
+  #   params_list: A list of num_variables elements, each of which is the
+  #       RAPPOR encoding parameters for a variable (a list itself).  If set,
+  #       it must be the same length as 'reports'.
   #   marginals: List of estimated marginals for each variable
   #   estimate_var: A flag telling whether to estimate the variance.
   #   em_iter_func: Function that implements the iterative EM algorithm.
@@ -330,9 +331,6 @@ ComputeDistributionEM <- function(reports, report_cohorts, maps,
   # Handle the case that the client wants to find the joint distribution of too
   # many variables.
   num_variables <- length(reports)
-  if (num_variables > 4) {
-    stop("Not comparing more than 4 variables")
-  }
 
   if (is.null(params) && is.null(params_list)) {
     stop("Either params or params_list must be passed")

--- a/analysis/R/decode_ngrams.R
+++ b/analysis/R/decode_ngrams.R
@@ -57,7 +57,7 @@ FindPairwiseCandidates <- function(report_data, N, ngram_params, params) {
     new_dist <- ComputeDistributionEM(report_subset,
                                       cohort_subset,
                                       maps, ignore_other = FALSE,
-                                      params, estimate_var = FALSE)
+                                      params = params, estimate_var = FALSE)
     new_dist
   }
 

--- a/analysis/R/fast_em.R
+++ b/analysis/R/fast_em.R
@@ -1,0 +1,104 @@
+# fast_em.R: Wrapper around analysis/cpp/fast_em.cc.
+#
+# This serializes the input, shells out, and deserializes the output.
+
+.Flatten <- function(list_of_matrices) {
+  listOfVectors <- lapply(list_of_matrices, as.vector)
+  #print(listOfVectors)
+
+  # unlist takes list to vector.
+  unlist(listOfVectors)
+}
+
+.WriteListOfMatrices <- function(list_of_matrices, f) {
+  flattened <- .Flatten(list_of_matrices)
+
+  # NOTE: UpdateJointConditional does outer product of dimensions!
+
+  # 3 letter strings are null terminated
+  writeBin('ne ', con = f)
+  num_entries <- length(list_of_matrices)
+  writeBin(num_entries, con = f)
+
+  Log('Wrote num_entries = %d', num_entries)
+
+  # For 2x3, this is 6
+  writeBin('es ', con = f)
+
+  entry_size <- as.integer(prod(dim(list_of_matrices[[1]])))
+  writeBin(entry_size, con = f)
+
+  Log('Wrote entry_size = %d', entry_size)
+
+  # now write the data
+  writeBin('dat', con = f)
+  writeBin(flattened, con = f)
+}
+
+# Display some stats before sending it over to C++.
+.SanityChecks <- function(joint_conditional) {
+    # Sanity checks
+
+    inf_counts <- lapply(joint_conditional, function(m) {
+      sum(m == Inf)
+    })
+    total_inf <- sum(as.numeric(inf_counts))
+
+    nan_counts <- lapply(joint_conditional, function(m) {
+      sum(is.nan(m))
+    })
+    total_nan <- sum(as.numeric(nan_counts))
+
+    zero_counts <- lapply(joint_conditional, function(m) {
+      sum(m == 0.0)
+    })
+    total_zero <- sum(as.numeric(zero_counts))
+
+    #sum(joint_conditional[joint_conditional == Inf, ])
+    Log('total inf: %s', total_inf)
+    Log('total nan: %s', total_nan)
+    Log('total zero: %s', total_zero)
+}
+
+ConstructFastEM <- function(em_executable, tmp_dir) {
+  # TODO:
+  # - check that number of dimensions is 2
+  # - Serialize joint_conditional.  This is the outer product thingy.
+  #   - Or maybe you can do an array of cond_report_dist, and then do outer
+  #   product in C++
+
+  return(function(joint_conditional, max_em_iters = 1000,
+                  epsilon = 10 ^ -6, verbose = FALSE,
+                  estimate_var = FALSE) {
+    entry_size <- prod(dim(joint_conditional[[1]]))
+    Log('entry size: %d', entry_size)
+
+    .SanityChecks(joint_conditional)
+
+    input_path <- file.path(tmp_dir, 'list_of_matrices.bin')
+    Log("Writing flattened list of matrices to %s", input_path)
+    f <- file(input_path, 'wb')  # binary file
+    .WriteListOfMatrices(joint_conditional, f)
+    close(f)
+    Log("Done writing %s", input_path)
+     
+    output_path <- file.path(tmp_dir, 'pij.bin')
+
+    cmd <- sprintf("%s %s %s %s", em_executable, input_path, output_path,
+                   max_em_iters)
+    Log("Shell command: %s", cmd)
+    system(cmd)
+    Log("Done running shell command")
+
+    pij <- readBin(con = output_path, what = "double", n = entry_size)
+
+    # Adjust dimensions
+    dim(pij) <- dim(joint_conditional[[1]])
+
+    Log("PIJ read from C++:")
+    print(pij)
+     
+    # est, sd, var_cov, hist
+    list(est = pij)
+  })
+}

--- a/analysis/R/fast_em.R
+++ b/analysis/R/fast_em.R
@@ -61,16 +61,18 @@
 }
 
 ConstructFastEM <- function(em_executable, tmp_dir) {
-  # TODO:
-  # - check that number of dimensions is 2
-  # - Serialize joint_conditional.  This is the outer product thingy.
-  #   - Or maybe you can do an array of cond_report_dist, and then do outer
-  #   product in C++
 
   return(function(joint_conditional, max_em_iters = 1000,
                   epsilon = 10 ^ -6, verbose = FALSE,
                   estimate_var = FALSE) {
-    entry_size <- prod(dim(joint_conditional[[1]]))
+    matrix_dims <- dim(joint_conditional[[1]])
+    # Check that number of dimensions is 2.
+    if (length(matrix_dims) != 2) {
+      Log('FATAL: Expected 2 dimensions, got %d', length(matrix_dims))
+      stop()
+    }
+
+    entry_size <- prod(matrix_dims)
     Log('entry size: %d', entry_size)
 
     .SanityChecks(joint_conditional)
@@ -93,7 +95,7 @@ ConstructFastEM <- function(em_executable, tmp_dir) {
     pij <- readBin(con = output_path, what = "double", n = entry_size)
 
     # Adjust dimensions
-    dim(pij) <- dim(joint_conditional[[1]])
+    dim(pij) <- matrix_dims
 
     Log("PIJ read from C++:")
     print(pij)

--- a/analysis/R/simulation.R
+++ b/analysis/R/simulation.R
@@ -79,7 +79,7 @@ EncodeAll <- function(x, cohorts, map, params, num_cores = 1) {
   candidates <- colnames(map[[1]])
   if (!all(x %in% candidates)) {
     stop("Some strings are not in the map. set(X) - set(candidates): ",
-         paste(setdiff(unique(x), candidates), collapse="_"),"\n")
+         paste(setdiff(unique(x), candidates), collapse=" "), "\n")
   }
   bfs <- mapply(function(x, y) y[, x], x, map[cohorts], SIMPLIFY = FALSE,
                 USE.NAMES = FALSE)

--- a/analysis/cpp/fast_em.cc
+++ b/analysis/cpp/fast_em.cc
@@ -1,0 +1,294 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <assert.h>
+#include <stdarg.h>  // va_list, etc.
+#include <stdio.h>  // fread()
+#include <stdlib.h>  // exit()
+#include <stdint.h>  // uint16_t
+#include <string.h>  // strcmp()
+#include <cmath>  // std::abs operates on doubles
+#include <cstdlib>  // strtol
+#include <string>
+#include <vector>
+
+using std::string;
+using std::vector;
+
+// Log messages to stdout.
+void log(const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  vprintf(fmt, args);
+  va_end(args);
+  printf("\n");
+}
+
+const int kTagLen = 4;  // 4 byte tags in the file format
+
+bool ExpectTag(FILE* f, const char* tag) {
+  char buf[kTagLen];
+
+  if (fread(buf, sizeof buf[0], kTagLen, f) != kTagLen) {
+    return false;
+  }
+  if (strcmp(buf, tag) != 0) {
+    log("Error: expected '%s'", tag);
+    return false;
+  }
+  return true;
+}
+
+static bool ReadListOfMatrices(
+    FILE* f, uint32_t* num_entries_out, uint32_t* entry_size_out,
+    vector<double>* v_out) {
+  if (!ExpectTag(f, "ne ")) {
+    return false;
+  }
+
+  // R integers are serialized as uint32_t
+  uint32_t num_entries;
+  if (fread(&num_entries, sizeof num_entries, 1, f) != 1) {
+    return false;
+  }
+
+  log("num entries: %d", num_entries);
+
+  if (!ExpectTag(f, "es ")) {
+    return false;
+  }
+
+  uint32_t entry_size;
+  if (fread(&entry_size, sizeof entry_size, 1, f) != 1) {
+    return false;
+  }
+  log("entry_size: %d", entry_size);
+
+  if (!ExpectTag(f, "dat")) {
+    return false;
+  }
+
+  // Now read dynamic data
+  uint32_t vec_length = num_entries * entry_size;
+
+  vector<double>& v = *v_out;
+  v.resize(vec_length);
+
+  if (fread(&v[0], sizeof v[0], vec_length, f) != vec_length) {
+    return false;
+  }
+
+  // Print out head for sanity
+  size_t n = 20;
+  for (size_t i = 0; i < n && i < v.size(); ++i) {
+    log("%d: %f", i, v[i]);
+  }
+
+  *num_entries_out = num_entries;
+  *entry_size_out = entry_size;
+
+  return true;
+}
+
+void PrintEntryVector(const vector<double>& cond_prob, size_t m,
+                      size_t entry_size) {
+  size_t c_base = m * entry_size;
+  log("cond_prob[m = %d] = ", m);
+  for (size_t i = 0; i < entry_size; ++i) {
+    printf("%e ", cond_prob[c_base + i]);
+  }
+  printf("\n");
+}
+
+void PrintPij(const vector<double>& pij) {
+  double sum = 0.0;
+  printf("PIJ:\n");
+  for (size_t i = 0; i < pij.size(); ++i) {
+    printf("%f ", pij[i]);
+    sum += pij[i];
+  }
+  printf("\n");
+  printf("SUM: %f\n", sum);  // sum is 1.0 after normalization
+  printf("\n");
+}
+
+// EM algorithm to iteratively estimate parameters.
+
+static void ExpectationMaximization(
+    uint32_t num_entries, uint32_t entry_size, const vector<double>& cond_prob,
+    int max_em_iters, double epsilon, vector<double>* pij_out) {
+  // Start out with uniform distribution.
+  vector<double> pij(entry_size, 0.0);
+  double init = 1.0 / entry_size;
+  for (size_t i = 0; i < pij.size(); ++i) {
+    pij[i] = init;
+  }
+  log("Initialized %d entries with %f", pij.size(), init);
+  PrintPij(pij);
+
+  vector<double> prev_pij(entry_size, 0.0);  // pij on previous iteration
+
+  log("Starting %d EM iterations", max_em_iters);
+
+  for (int em_iter = 0; em_iter < max_em_iters; ++em_iter) {
+    log("fast_em iteration %d", em_iter);
+    //
+    // lapply() step.
+    //
+
+    // Computed below as a function of old Pij and conditional probability for
+    // each report.
+    vector<double> new_pij(entry_size, 0.0);
+
+    // m is the matrix index, giving the conditional probability matrix for a
+    // single report.
+    for (size_t m = 0; m < num_entries; ++m) {
+      vector<double> z(entry_size, 0.0);
+
+      double sum_z = 0.0;
+
+      // base index for the matrix corresponding to a report.
+      size_t c_base = m * entry_size;
+
+      for (size_t i = 0; i < entry_size; ++i) {  // multiply and running sum
+        size_t c_index = c_base + i;
+        z[i] = cond_prob[c_index] * pij[i];
+        sum_z += z[i];
+      }
+
+      // Normalize and Reduce("+", wcp) step.  These two steps are combined for
+      // memory locality.
+      for (size_t i = 0; i < entry_size; ++i) {
+        new_pij[i] += z[i] / sum_z;
+      }
+    }
+
+    // Divide outside the loop
+    for (size_t i = 0; i < entry_size; ++i) {
+      new_pij[i] /= num_entries;
+    }
+
+    PrintPij(new_pij);
+
+    //
+    // Check for termination
+    //
+    double max_dif = 0.0;
+    for (size_t i = 0; i < entry_size; ++i) {
+      double dif = std::abs(new_pij[i] - pij[i]);
+      if (dif > max_dif) {
+        max_dif = dif;
+      }
+    }
+
+    pij = new_pij;  // copy
+
+    log("max_dif: %e", em_iter, max_dif);
+
+    if (max_dif < epsilon) {
+      log("Early EM termination: %e < %e", max_dif, epsilon);
+      break;
+    }
+  }
+
+  *pij_out = pij;
+}
+
+// Write the probabilities as a flat list of doubles.  The caller knows what
+// the dimensions are.
+bool WriteMatrix(const vector<double>& pij, FILE* f_out) {
+  size_t n = pij.size();
+  return fwrite(&pij[0], sizeof pij[0], n, f_out) == n;
+}
+
+// Like atoi, but with basic (not exhaustive) error checking.
+bool StringToInt(const char* s, int* result) {
+  bool ok = true;
+  char* end;  // mutated by strtol
+
+  *result = strtol(s, &end, 10);  // base 10
+  // If strol didn't consume any characters, it failed.
+  if (end == s) {
+    ok = false;
+  }
+  return ok;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 4) {
+    log("Usage: read_numeric INPUT OUTPUT max_em_iters");
+    return 1;
+  }
+
+  char* in_filename = argv[1];
+  char* out_filename = argv[2];
+
+  int max_em_iters;
+  if (!StringToInt(argv[3], &max_em_iters)) {
+    log("Error parsing max_em_iters");
+    return 1;
+  }
+
+  FILE* f = fopen(in_filename, "rb");
+  if (f == NULL) {
+    return 1;
+  }
+
+  // Try opening first so we don't do a long computation and then fail.
+  FILE* f_out = fopen(out_filename, "wb");
+  if (f_out == NULL) {
+    return 1;
+  }
+
+  uint32_t num_entries;
+  uint32_t entry_size;
+  vector<double> cond_prob;
+  if (!ReadListOfMatrices(f, &num_entries, &entry_size, &cond_prob)) {
+    log("Error reading list of matrices");
+    return 1;
+  }
+
+  fclose(f);
+
+  // Sanity check
+  double debug_sum = 0.0;
+  for (size_t m = 0; m < num_entries; ++m) {
+    // base index for the matrix corresponding to a report.
+    size_t c_base = m * entry_size;
+    for (size_t i = 0; i < entry_size; ++i) {  // multiply and running sum
+      debug_sum += cond_prob[c_base + i];
+    }
+  }
+  log("Debug sum: %f", debug_sum);
+
+  double epsilon = 1e-6;
+  log("epsilon: %f", epsilon);
+
+  vector<double> pij(num_entries);
+  ExpectationMaximization(
+      num_entries, entry_size, cond_prob, max_em_iters, epsilon, &pij);
+
+  for (size_t i = 0; i < entry_size; ++i) {
+    log("result pij[%d] = %e", i, pij[i]);
+  }
+
+  if (!WriteMatrix(pij, f_out)) {
+    log("Error writing result matrix");
+    return 1;
+  }
+  fclose(f_out);
+
+  log("Done");
+  return 0;
+}

--- a/analysis/cpp/fast_em.cc
+++ b/analysis/cpp/fast_em.cc
@@ -80,7 +80,7 @@ static bool ReadListOfMatrices(
   }
 
   // Now read dynamic data
-  uint32_t vec_length = num_entries * entry_size;
+  size_t vec_length = num_entries * entry_size;
 
   vector<double>& v = *v_out;
   v.resize(vec_length);

--- a/analysis/cpp/run.sh
+++ b/analysis/cpp/run.sh
@@ -8,15 +8,7 @@ set -o pipefail
 set -o errexit
 
 # Call gcc with the flags we like.
-
-# -O3: Optimize yet more. -O3 turns on all optimizations specified by -O2 and
-# also turns on the -finline-functions, -funswitch-loops,
-# -fpredictive-commoning, -fgcse-after-reload, -ftree-loop-vectorize,
-# -ftree-loop-distribute-patterns, -ftree-slp-vectorize, -fvect-cost-model,
-# -ftree-partial-pre and -fipa-cp-clone options.
-#
-# NOTE: This matters a lot for fast_em!  (More than 5x speedup over
-# unoptimized)
+# NOTE: -O3 does a lot for fast_em.  (More than 5x speedup over unoptimized)
 
 cpp-compiler() {
   g++ -Wall -Wextra -O3 "$@"

--- a/analysis/test/association_test.R
+++ b/analysis/test/association_test.R
@@ -95,7 +95,7 @@ Simulate <- function(N, num_variables, params, variable_opts = NULL,
     maps <- lapply(1:num_variables, function(x) map)
     # Build the reports
     report <- EncodeAll(truth$variables[[1]], truth$cohorts[[1]],
-                        map$map, params)
+                        map$map_by_cohort, params)
     reports <- lapply(1:num_variables, function(x) report)
   } else {
     # Build the maps
@@ -105,7 +105,7 @@ Simulate <- function(N, num_variables, params, variable_opts = NULL,
     # Build the reports
     reports <- lapply(1:num_variables, function(x)
                       EncodeAll(truth$variables[[x]], truth$cohorts[[x]],
-                                maps[[x]]$map, params))
+                                maps[[x]]$map_by_cohort, params))
   }
 
   list(reports = reports, cohorts = truth$cohorts,
@@ -163,13 +163,13 @@ TestComputeDistributionEM <- function() {
   small_map <- map
 
   for (i in 1:params$m) {
-    locs <- which(map$map[[i]][, 1])
-    small_map$map[[i]] <- sparseMatrix(locs, rep(1, length(locs)),
-                                       dims = c(params$k, 1))
-    locs <- which(map$rmap[, 1])
-    colnames(small_map$map[[i]]) <- sim$strs[1]
+    locs <- which(map$map_by_cohort[[i]][, 1])
+    small_map$map_by_cohort[[i]] <- sparseMatrix(locs, rep(1, length(locs)),
+                                                 dims = c(params$k, 1))
+    locs <- which(map$all_cohorts_map[, 1])
+    colnames(small_map$map_by_cohort[[i]]) <- sim$strs[1]
   }
-  small_map$rmap <- do.call("rBind", small_map$map)
+  small_map$all_cohorts_map <- do.call("rBind", small_map$map_by_cohort)
 
   dist <- ComputeDistributionEM(list(sim$reports[[1]]),
                                 list(sim$cohorts[[1]]),

--- a/analysis/test/association_test.R
+++ b/analysis/test/association_test.R
@@ -138,7 +138,8 @@ TestComputeDistributionEM <- function() {
   # Test 1: Delta function pmf
   joint_dist <- ComputeDistributionEM(sim$reports,
                                       sim$cohorts, sim$maps,
-                                      ignore_other = TRUE, params,
+                                      ignore_other = TRUE,
+                                      params = params,
                                       marginals = NULL,
                                       estimate_var = FALSE)
   # The recovered distribution should be close to the delta function.
@@ -150,7 +151,8 @@ TestComputeDistributionEM <- function() {
                                 list(sim$cohorts[[1]]),
                                 list(sim$maps[[1]]),
                                 ignore_other = TRUE,
-                                params, marginals = NULL,
+                                params = params,
+                                marginals = NULL,
                                 estimate_var = FALSE)
   checkTrue(abs(dist$fit["1"] - 0.5) < 0.01)
 
@@ -173,20 +175,19 @@ TestComputeDistributionEM <- function() {
                                 list(sim$cohorts[[1]]),
                                 list(small_map),
                                 ignore_other = FALSE,
-                                params,
+                                params = params,
                                 marginals = NULL,
                                 estimate_var = FALSE)
 
   # The recovered distribution should be uniform over 2 strings.
   checkTrue(abs(dist$fit[1] - 0.5) < 0.1)
 
-
   # Test 4: Test the variance is 1/N
   variable_opts <- list(deterministic = TRUE, num_strings = 1)
   sim <- Simulate(N, num_variables = 1, params, variable_opts)
   dist <- ComputeDistributionEM(sim$reports, sim$cohorts,
                                 sim$maps, ignore_other = TRUE,
-                                params, marginals = NULL,
+                                params = params, marginals = NULL,
                                 estimate_var = TRUE)
 
   checkEqualsNumeric(dist$em$var_cov[1, 1], 1 / N)
@@ -197,7 +198,7 @@ TestComputeDistributionEM <- function() {
   sim <- Simulate(N, num_variables = 2, params, variable_opts)
   dist <- ComputeDistributionEM(sim$reports, sim$cohorts,
                                 sim$maps, ignore_other = TRUE,
-                                params, marginals = NULL,
+                                params = params, marginals = NULL,
                                 estimate_var = FALSE)
 
   checkTrue(abs(dist$fit["1", "1"] - 0.5) < 0.15)
@@ -212,7 +213,7 @@ TestComputeDistributionEM <- function() {
   sim <- Simulate(N, num_variables = 2, params, variable_opts)
   dist <- ComputeDistributionEM(sim$reports, sim$cohorts,
                                 sim$maps, ignore_other = TRUE,
-                                params, marginals = NULL,
+                                params = params, marginals = NULL,
                                 estimate_var = FALSE)
 
   print_dist <- TRUE  # to print joint distribution, set to TRUE
@@ -240,3 +241,26 @@ TestComputeDistributionEM <- function() {
   checkTrue(dist$fit["3", "1"] < 0.02)
   checkTrue(dist$fit["3", "2"] < 0.02)
 }
+
+TestEM <- function() {
+  d = matrix(c(1,1,2,2,3,3), nrow=3, ncol=2)
+  d = d / sum(d)
+
+  e = matrix(c(3,3,2,2,1,1), nrow=3, ncol=2)
+  e = e / sum(e)
+
+  #f = matrix(c(0,2,2,2,2,2), nrow=3, ncol=2)
+  #f = f / sum(f)
+
+  cond_prob = list(d, e, d)  # 3 reports
+  print(cond_prob)
+
+  # Mechanical test of 4 iterations.  em$hist has 5 elements.
+  em <- EM(cond_prob, max_em_iters=4)
+  print(structure(em))
+
+  return(cond_prob)
+}
+
+#TestEM()
+

--- a/analysis/test/unknowns_test.R
+++ b/analysis/test/unknowns_test.R
@@ -85,7 +85,7 @@ TestEstimateDictionary <- function() {
   if (num_strs == 1) {
     checkTrue(res$found_candidates == sort(unique(sim$strs)))
   } else {
-    checkTrue (all.equal(res$found_candidates, sort(unique(sim$strs))))
+    checkTrue(all.equal(res$found_candidates, sort(unique(sim$strs))))
   }
 }
 

--- a/bin/decode-assoc
+++ b/bin/decode-assoc
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Decode a distribution from summed RAPPOR reports.
+# Decode multidimensional reports.
 #
 # This is a tiny shell wrapper around R.
 
@@ -14,4 +14,4 @@ readonly RAPPOR_REPO=$THIS_DIR/../
 
 # RAPPOR_REPO is used by source() statements to find .R files.
 export RAPPOR_REPO
-$THIS_DIR/decode_dist.R "$@"
+$THIS_DIR/decode_assoc.R "$@"

--- a/bin/decode_assoc.R
+++ b/bin/decode_assoc.R
@@ -143,9 +143,10 @@ CreateAssocStringMap <- function(map, params) {
   all_cohorts_map <- map$map
 
   k <- params$k
-  map_by_cohort <- lapply(1:params$m, function(cohort) {
-    row_indices <- seq(from = ((cohort - 1) * k + 1), length.out = k)
-    all_cohorts_map[row_indices, ]
+  map_by_cohort <- lapply(0 : (params$m-1), function(cohort) {
+    begin <- cohort * k
+    end <- (cohort + 1) * k
+    all_cohorts_map[(begin+1) : end, ]
   })
 
   list(all_cohorts_map = all_cohorts_map, map_by_cohort = map_by_cohort)

--- a/bin/decode_assoc.R
+++ b/bin/decode_assoc.R
@@ -1,0 +1,420 @@
+#!/usr/bin/env Rscript
+#
+# Command line tool to decode multidimensional reports.  It's a simple wrapper
+# around functions in association.R.
+
+library(optparse)
+
+#
+# Command line parsing.  Do this first before loading libraries to catch errors
+# quickly.  Loading libraries in R is slow.
+#
+
+# Display an error string and quit.
+UsageError <- function(...) {
+  cat(sprintf(...))
+  cat('\n')
+  quit(status = 1)
+}
+
+option_list <- list(
+    make_option(
+        "--metric-name", dest="metric_name", default="",
+        help="Name of the metric; metrics contain variables (required)"),
+    make_option(
+        "--reports", default="",
+        help="CSV file with reports; each variable is a column (required)"),
+    make_option(
+        "--schema", default="",
+        help="CSV file with variable types and metadata (required)"),
+    make_option(
+        "--params-dir", dest="params_dir", default="",
+        help="Directory where parameter CSV files are stored (required)"),
+
+    make_option(
+        "--var1", default="",
+        help="Name of first variable (required)"),
+    make_option(
+        "--var2", default="",
+        help="Name of second variable (required)"),
+
+    make_option(
+        "--map1", default="",
+        help="Path to map file, if var1 is a string"),
+    make_option(
+        "--map2", default="",
+        help="Path to map file, if var2 is a string"),
+
+    make_option(
+        "--output-dir", dest="output_dir", default=".",
+        help="Output directory (default .)"),
+
+    # Options that speed it up
+    make_option(
+        "--reports-sample-size", dest="reports_sample_size", default=-1,
+        help="Only analyze a random sample of this size.  This is for
+              limiting the execution time at the expense of accuracy."),
+    make_option(
+        "--num-cores", dest="num_cores", default=1,
+        help="Number of cores for mclapply to use.  Speeds up the parts
+              of the computation proportional to the number of reports,
+              EXCEPT the EM step, which can be sped up by native code."),
+    make_option(
+        "--max-em-iters", dest="max_em_iters", default=1000,
+        help="Maximum number of EM iterations"),
+    make_option(
+        "--em-executable", dest="em_executable", default="",
+        help="Shell out to this executable for an accelerated implementation
+             of EM."),
+    make_option(
+        "--tmp-dir", dest="tmp_dir", default="/tmp",
+        help="Use this tmp dir to communicate with the EM executable"),
+
+    make_option(
+        "--test-em-executable", dest="test_em_executable", default=FALSE,
+        action="store_true",
+        help="Just run a test of the EM executable (i.e. to make sure it
+              exists, etc.)")
+)
+
+ParseOptions <- function() {
+  # NOTE: This API is bad; if you add positional_arguments, the return value
+  # changes!
+  parser <- OptionParser(option_list = option_list)
+  opts <- parse_args(parser)
+
+  if (opts$test_em_executable) {  # only test validity in non-test mode
+    return(opts)
+  }
+
+  if (opts$metric_name == "") {
+    UsageError("--metric-name is required.")
+  }
+  if (opts$reports== "") {
+    UsageError("--reports is required.")
+  }
+  if (opts$schema == "") {
+    UsageError("--schema is required.")
+  }
+  if (opts$params_dir == "") {
+    UsageError("--params-dir is required.")
+  }
+  if (opts$var1 == "") {
+    UsageError("--var1 is required.")
+  }
+  if (opts$var2 == "") {
+    UsageError("--var2 is required.")
+  }
+
+  return(opts)
+}
+
+if (!interactive()) {
+  opts <- ParseOptions()
+}
+
+#
+# Load libraries and source our own code.
+#
+
+library(RJSONIO)
+
+# So we don't have to change pwd
+source.rappor <- function(rel_path)  {
+  abs_path <- paste0(Sys.getenv("RAPPOR_REPO", ""), rel_path)
+  source(abs_path)
+}
+
+source.rappor("analysis/R/association.R")
+source.rappor("analysis/R/fast_em.R")
+source.rappor("analysis/R/read_input.R")
+source.rappor("analysis/R/util.R")
+
+options(stringsAsFactors = FALSE)
+options(max.print = 100)  # So our structure() debug calls look better
+
+#
+# Copied from Ananth's change.
+#
+# TODO: call it assoc_map everywhere, rename $rmap and $map fields!
+# 
+# - assoc_map$all_cohorts
+# - assoc_map$by_cohort
+#
+# Then the vector can be assoc_map_list
+
+# This function processes the maps loaded using ReadMapFile Association
+# analysis requires a map object with a map field that has the map split into
+# cohorts and an rmap field that has all the cohorts combined
+#
+# Arguments:
+#       map = map object with cohorts as sparse matrix in
+#             object map$map
+#             This is the expected object from ReadMapFile
+#       params = data field with parameters
+CorrectMapForAssoc <- function(map, params, num_cores) {
+  # should be map_all or something
+  map$rmap <- map$map
+
+  # should be $map_by_cohort
+  map$map <- mclapply(1:params$m, function(i) {
+    map$rmap[seq(from = ((i - 1) * params$k + 1),
+                 length.out = params$k),]
+  }, mc.cores = num_cores)  # TODO: use opts$num_cores
+  map
+}
+
+# Hack to create a map for booleans.  We should use basic RAPPOR instead.
+CreateBoolMap <- function(params) {
+  names <- c("FALSE", "TRUE")
+  by_cohort <- lapply(1:params$m, function(z) {
+    # The (1,1) cell is false and the (1,2) cell is true.
+    m <- sparseMatrix(c(1), c(2), dims = c(1, 2))
+    colnames(m) <- names
+    m
+  })
+
+  all_cohorts <- sparseMatrix(1:params$m, rep(2, params$m))
+  colnames(all_cohorts) <- names
+
+  # Make the strs stand out?
+  #list(map = by_cohort, rmap = all_cohorts, strs = c("fa", "tr"))
+  list(map = by_cohort, rmap = all_cohorts)
+}
+
+# Run a test of the EM executable
+TestEmExecutable <- function(opts) {
+  d = matrix(c(1,1,2,2,3,3), nrow=3, ncol=2)
+  d = d / sum(d)
+
+  e = matrix(c(3,3,2,2,1,1), nrow=3, ncol=2)
+  e = e / sum(e)
+
+  cond_prob = list(d, e, d)  # 3 reports
+  print(cond_prob)
+
+  em_iter_func = ConstructFastEM(opts$em_executable, opts$tmp_dir)
+
+  em_iter_func(cond_prob, max_em_iters=4)
+}
+
+main <- function(opts) {
+  if (opts$test_em_executable) {
+    TestEmExecutable(opts)
+    Log('Done testing EM executable')
+    return()
+  }
+
+  Log("decode-assoc")
+
+  schema <- read.csv(opts$schema)
+  Log("Read %d vars from schema", nrow(schema))
+
+  schema1 <- schema[schema$metric == opts$metric_name &
+                    schema$var == opts$var1, ]
+  if (nrow(schema1) == 0) {
+    UsageError("Couldn't find metric '%s', field '%s' in schema",
+               opts$metric_name, opts$var1)
+  }
+  schema2 <- schema[schema$metric == opts$metric_name &
+                    schema$var== opts$var2, ]
+  if (nrow(schema2) == 0) {
+    UsageError("Couldn't find metric '%s', field '%s' in schema",
+               opts$metric_name, opts$var2)
+  }
+
+  if (schema1$params != schema2$params) {
+    UsageError('var1 and var2 should have the same params (%s != %s)',
+               schema1$params, schema2$params)
+  }
+  params_name <- schema1$params
+  params_path <- file.path(opts$params_dir, paste0(params_name, '.csv'))
+  params <- ReadParameterFile(params_path)
+
+  var1_type <- schema1$var_type
+  var2_type <- schema2$var_type
+
+  # TODO: Remove these limitations.
+  if (var1_type != "string") {
+    UsageError("Variable 1 should be a string (%s is of type %s)", opts$var1,
+               var1_type)
+  }
+  if (var2_type != "boolean") {
+    UsageError("Variable 2 should be a boolean (%s is of type %s)", opts$var2,
+               var2_type)
+  }
+
+  if (var1_type == "string") {
+    if (opts$map1 == "") {
+      UsageError("--map1 must be provided when --var1 is a string (var = %s)",
+                 opts$var1)
+    }
+    # NOTE: We restore the default quote, which for some reason LoadMapFile
+    # overrides.
+    t <- system.time( LoadMapFile(opts$map1, quote = "\"'") )
+    Log("Loading map file took %.1f seconds", t[['elapsed']])
+    # for 100k map file: 31 seconds to load map and write cache; 2.2 seconds to
+    # read cache
+    # LoadMapFile has the side effect of putting 'map' in the global enviroment.
+  }
+
+  # Important: first column is cohort (integer); the rest are variables, which
+  # are ASCII bit strings.
+  reports <- read.csv(opts$reports, colClasses=c("character"), as.is = TRUE)
+
+  N <- nrow(reports)
+  Log("Read %d reports", N)
+  print(head(reports))
+
+  # Sample reports if specified.
+  if (opts$reports_sample_size != -1) {
+    if (N > opts$reports_sample_size) {
+      indices <- sample(1:N, opts$reports_sample_size)
+      reports <- reports[indices, ]
+      Log("Created a sample of %d reports", nrow(reports))
+    } else {
+      Log("Got less than %d reports, not sampling", opts$reports_sample_size)
+    }
+  }
+
+  num_vars <- 2  # hard-coded for now
+
+  # Convert strings to integers
+  cohorts <- as.integer(reports$cohort)
+
+  # Hack for Chrome: like AdjustCounts in decode_dist.R.
+  cohorts <- cohorts %% params$m
+
+  # Assume the input has 0-based cohorts, and change to 1-based cohorts.
+  cohorts <- cohorts + 1
+
+  # i.e. create a list of length 2, with identical cohorts.
+  # NOTE: Basic RAPPOR doesn't need cohorts.
+  cohorts_list <- rep(list(cohorts), num_vars)
+
+  #print('COHORTS')
+  #print(structure(cohorts_list))
+  #print(length(cohorts_list))
+
+  # i.e. create a list of length 2, with identical cohorts.
+  string_params <- params
+
+  bool_params <- params
+  # HACK: Make this the boolean.  The Decode() step uses k.  (Note that R makes
+  # a copy here)
+  bool_params$k <- 1
+
+  params_list <- list(bool_params, string_params)
+
+  #print(structure(params_list))
+  #print(length(cohorts_list))
+
+  Log('CorrectMapForAssoc (%d cores)', opts$num_cores)
+  # give it $rmap, etc.
+  string_map <- CorrectMapForAssoc(map, params, opts$num_cores)
+
+  #Log('String map:')
+  #print(structure(string_map))
+
+  Log('CreateBoolMap')
+  bool_map <- CreateBoolMap(params)
+
+  map_list <- list(bool_map, string_map)
+  #print(structure(map_list))
+
+  string_var <- reports[[opts$var1]]
+  bool_var <- reports[[opts$var2]]
+
+  Log('String Var')
+  print(head(table(string_var)))
+  cat('\n')
+
+  Log('Bool Var')
+  print(head(table(bool_var)))
+  cat('\n')
+
+  # Split ASCII strings into array of numerics (as required by assoc analysis)
+
+  Log('Splitting string reports (%d cores)', opts$num_cores)
+  string_reports <- mclapply(string_var, function(x) {
+    # function splits strings and converts them to numeric values
+    # rev needed for endianness
+    rev(as.integer(strsplit(x, split = "")[[1]]))
+  }, mc.cores = opts$num_cores)
+
+  Log('Splitting bool reports (%d cores)', opts$num_cores)
+  # Has to be an list of length 1 integer vectors
+  bool_reports <- mclapply(bool_var, function(x) {
+    as.integer(x)
+  }, mc.cores = opts$num_cores)
+
+  reports_list <- list(bool_reports, string_reports)
+  #print(structure(reports_list))
+
+  Log('Association for %d vars', length(reports_list))
+
+  if (opts$em_executable != "") {
+    Log('Will shell out to %s for native EM implementation', opts$em_executable)
+    em_iter_func = ConstructFastEM(opts$em_executable, opts$tmp_dir)
+  } else {
+    Log('Will use R implementation of EM (slow)')
+    em_iter_func <- EM
+  }
+
+  em_result <- ComputeDistributionEM(reports_list, cohorts_list, map_list,
+                                     ignore_other = FALSE,
+                                     params_list = params_list,
+                                     marginals = NULL,
+                                    estimate_var = FALSE,
+                                    num_cores = opts$num_cores,
+                                    em_iter_func = em_iter_func,
+                                    max_em_iters = opts$max_em_iters)
+  Log("Association results:")
+  fit <- em_result$fit
+  print(fit)
+
+  pretty <- apply(fit * 100, 1, function(row) sprintf("%.1f%%", row))
+  Log("Percentages:")
+  print(pretty)
+
+  fit_df <- as.data.frame(fit)
+  print(fit_df)
+
+  results_csv_path <- file.path(opts$output_dir, 'assoc-results.csv')
+  write.csv(fit_df, file = results_csv_path)
+  Log("Wrote %s", results_csv_path)
+
+  # Measure elapsed time as close to the end as possible
+  total_elapsed_time <- proc.time()[['elapsed']]
+
+  metrics <- list(num_reports = N,
+                  reports_sample_size = opts$reports_sample_size,
+                  # fit is a matrix
+                  estimate_dimensions = dim(fit),
+                  # should sum to near 1.0
+                  sum_estimates = sum(fit),
+                  total_elapsed_time = total_elapsed_time,
+                  em_elapsed_time = em_result$em_elapsed_time)
+
+  metrics_json_path <- file.path(opts$output_dir, 'assoc-metrics.json')
+  writeLines(toJSON(metrics), con = metrics_json_path)
+  Log("Wrote %s", metrics_json_path)
+   
+  Log('DONE decode-assoc')
+}
+
+# reports: Simulate()   EncodeAll()         sim$reports 
+#  uses mclapply() and adds noise
+#
+# cohorts: Simulate()   SamplePopulations() truth$cohorts 
+#  lapply()
+#
+# maps: CreateMap() in simulation.R
+#   list(map, rmap, map_pos)
+# params: Is this a list or not?  Uses vector-filling I guess.
+
+# See TestComputeDistributionEM in association_test.R
+
+if (!interactive()) {
+  main(opts)
+}

--- a/bin/decode_assoc.R
+++ b/bin/decode_assoc.R
@@ -263,8 +263,9 @@ main <- function(opts) {
   reports <- read.csv(opts$reports, colClasses=c("character"), as.is = TRUE)
 
   N <- nrow(reports)
-  Log("Read %d reports", N)
+  Log("Read %d reports.  Preview:", N)
   print(head(reports))
+  cat('\n')
 
   # Sample reports if specified.
   if (opts$reports_sample_size != -1) {
@@ -277,7 +278,7 @@ main <- function(opts) {
     }
   }
 
-  num_vars <- 2  # hard-coded for now
+  num_vars <- 2  # hard-coded for now, since there is --var1 and --var2.
 
   # Convert strings to integers
   cohorts <- as.integer(reports$cohort)
@@ -292,10 +293,6 @@ main <- function(opts) {
   # NOTE: Basic RAPPOR doesn't need cohorts.
   cohorts_list <- rep(list(cohorts), num_vars)
 
-  #print('COHORTS')
-  #print(structure(cohorts_list))
-  #print(length(cohorts_list))
-
   # i.e. create a list of length 2, with identical cohorts.
   string_params <- params
 
@@ -306,15 +303,9 @@ main <- function(opts) {
 
   params_list <- list(bool_params, string_params)
 
-  #print(structure(params_list))
-  #print(length(cohorts_list))
-
   Log('CorrectMapForAssoc (%d cores)', opts$num_cores)
   # give it $rmap, etc.
   string_map <- CorrectMapForAssoc(map, params, opts$num_cores)
-
-  #Log('String map:')
-  #print(structure(string_map))
 
   Log('CreateBoolMap')
   bool_map <- CreateBoolMap(params)
@@ -325,15 +316,15 @@ main <- function(opts) {
   string_var <- reports[[opts$var1]]
   bool_var <- reports[[opts$var2]]
 
-  Log('String Var')
+  Log('Preview of string var:')
   print(head(table(string_var)))
   cat('\n')
 
-  Log('Bool Var')
+  Log('Preview of bool var:')
   print(head(table(bool_var)))
   cat('\n')
 
-  # Split ASCII strings into array of numerics (as required by assoc analysis)
+  # Split ASCII strings into array of numerics (as required by association.R)
 
   Log('Splitting string reports (%d cores)', opts$num_cores)
   string_reports <- mclapply(string_var, function(x) {
@@ -349,7 +340,6 @@ main <- function(opts) {
   }, mc.cores = opts$num_cores)
 
   reports_list <- list(bool_reports, string_reports)
-  #print(structure(reports_list))
 
   Log('Association for %d vars', length(reports_list))
 
@@ -402,18 +392,6 @@ main <- function(opts) {
    
   Log('DONE decode-assoc')
 }
-
-# reports: Simulate()   EncodeAll()         sim$reports 
-#  uses mclapply() and adds noise
-#
-# cohorts: Simulate()   SamplePopulations() truth$cohorts 
-#  lapply()
-#
-# maps: CreateMap() in simulation.R
-#   list(map, rmap, map_pos)
-# params: Is this a list or not?  Uses vector-filling I guess.
-
-# See TestComputeDistributionEM in association_test.R
 
 if (!interactive()) {
   main(opts)

--- a/bin/decode_assoc.R
+++ b/bin/decode_assoc.R
@@ -181,7 +181,13 @@ ResultMatrixToDataFrame <- function(m, string_var_name, bool_var_name) {
 
   dimnames(m) <- dim_names
   # http://stackoverflow.com/questions/15885111/create-data-frame-from-a-matrix-in-r
-  as.data.frame(as.table(m))
+  fit_df <- as.data.frame(as.table(m))
+
+  # The as.table conversion give syou a Freq column.  Call it "proportion" to
+  # be consistent with single variable analysis.
+  colnames(fit_df)[colnames(fit_df) == "Freq"] <- "proportion" 
+
+  fit_df
 }
 
 main <- function(opts) {

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -152,13 +152,4 @@ decode-assoc-both() {
   banner "Wrote $log"
 }
 
-# Run decode-assoc in a mode that only tests the EM step (i.e. it doesn't run the
-# conditional step)
-em-executable() {
-  build-em-executable
-  time ./decode-assoc \
-    --test-em-executable \
-    --em-executable $EM_EXECUTABLE
-}
-
 "$@"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -10,6 +10,17 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
+readonly THIS_DIR=$(dirname $0)
+readonly RAPPOR_SRC=$(cd $THIS_DIR/.. && pwd)
+readonly EM_EXECUTABLE=$RAPPOR_SRC/analysis/cpp/_tmp/fast_em
+
+source $RAPPOR_SRC/util.sh
+
+
+decode-dist-help() {
+  time ./decode-dist --help
+}
+
 decode-dist() {
   # ./demo.sh quick-python creates these files
   local case_dir=../_tmp/python/demo3
@@ -27,6 +38,127 @@ decode-dist() {
   head _tmp/results.csv 
   echo
   cat _tmp/metrics.json
+}
+
+decode-assoc-help() {
+  time ./decode-assoc --help
+}
+
+write-assoc-testdata() {
+  mkdir -p _tmp
+
+  export PYTHONPATH=$RAPPOR_SRC/client/python
+
+  cat >_tmp/true_values.csv <<EOF 
+domain,flag..HTTPS
+google.com,1
+google.com,1
+yahoo.com,1
+yahoo.com,0
+bing.com,1
+bing.com,1
+bing.com,0
+EOF
+
+  local num_bits=8
+  local num_hashes=2
+  local num_cohorts=128
+
+  local prob_p=0.25
+  local prob_q=0.75
+  local prob_f=0.5
+
+  # 7 items in the input.  7000 items is enough.
+  local assoc_testdata_count=1000
+
+  ../tests/rappor_sim.py \
+    --assoc-testdata $assoc_testdata_count \
+    --num-bits $num_bits \
+    --num-hashes $num_hashes \
+    --num-cohorts $num_cohorts \
+    -p $prob_p \
+    -q $prob_q \
+    -f $prob_f \
+    < _tmp/true_values.csv \
+    > _tmp/reports.csv
+
+  # Define a string variable and a boolean varaible.
+  cat >_tmp/schema.csv <<EOF 
+metric, var, var_type, params
+m,domain,string,m_params
+m,flag..HTTPS,boolean,m_params
+EOF
+
+  cat >_tmp/m_params.csv <<EOF
+k,h,m,p,q,f
+$num_bits,$num_hashes,$num_cohorts,$prob_p,$prob_q,$prob_f
+EOF
+
+  cat >_tmp/domain_candidates.csv <<EOF
+google.com
+yahoo.com
+bing.com
+EOF
+
+  # Hash candidates to create map.
+  ../analysis/tools/hash_candidates.py _tmp/m_params.csv \
+    < _tmp/domain_candidates.csv \
+    > _tmp/domain_map.csv
+    
+  banner "Wrote testdata in _tmp"
+}
+
+# Run the R version of association.
+decode-assoc() {
+  time ./decode-assoc \
+    --metric-name m \
+    --schema _tmp/schema.csv \
+    --reports _tmp/reports.csv \
+    --params-dir _tmp \
+    --var1 domain \
+    --var2 flag..HTTPS \
+    --map1 _tmp/domain_map.csv \
+    --max-em-iters 10 \
+    --num-cores 2 \
+    --output-dir _tmp \
+    "$@"
+}
+
+build-em-executable() {
+  pushd ../analysis/cpp >/dev/null
+  ./run.sh build-fast-em
+  popd >/dev/null
+}
+
+decode-assoc-cpp() {
+  build-em-executable
+  decode-assoc --em-executable "$EM_EXECUTABLE"
+}
+
+# TODO: Compare these results somehow?  Or just eyeball them.
+decode-assoc-both() {
+  write-assoc-testdata
+
+  local log=_tmp/em-slow.log
+
+  banner "Running slow association with R EM implementation"
+  decode-assoc | tee $log
+  banner "Wrote $log"
+
+  local log=_tmp/em-fast.log
+
+  banner "Running slow association with C++ EM implementation"
+  decode-assoc-cpp | tee $log
+  banner "Wrote $log"
+}
+
+# Run decode-assoc in a mode that only tests the EM step (i.e. it doesn't run the
+# conditional step)
+em-executable() {
+  build-em-executable
+  time ./decode-assoc \
+    --test-em-executable \
+    --em-executable $EM_EXECUTABLE
 }
 
 "$@"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -118,10 +118,13 @@ decode-assoc() {
     --var1 domain \
     --var2 flag..HTTPS \
     --map1 _tmp/domain_map.csv \
+    --create-bool-map \
     --max-em-iters 10 \
     --num-cores 2 \
     --output-dir _tmp \
     "$@"
+
+  head _tmp/assoc-*
 }
 
 build-em-executable() {


### PR DESCRIPTION
- Added bin/decode-assoc command line tool for automation.  Define and read a new schema so we know whether variables are string or boolean, and what their encoding parameters are.
- bin/test.sh: Add tests for bin/decode-assoc, for (string x boolean) problem
  - Add Boolean RAPPOR encoding  (no hashing step) to the Python client with Encoder.encode_bits
  - Add association testdata generation to rappor_sim.py

- Optimizations
  - In association.R, remove from GetCondProb() any computation that doesn't depend on the report.  (e.g. 100x-1000x speedup for the joint conditional stage)
  - Use mclapply in R for the steps that did lapply() over all reports (N).  The number of cores is controlled by decode-assoc --num-cores.
  - Provide an alternative implementation of EM in C++ in analysis/cpp/fast_em.cc (analysis/R/fast_em.R is a wrapper that does serialization and a system() call)  ~100x speedup.

- Fixed bugs in the k=1 case, due to R matrix/vector confusion (adapted from Ananth's changes)
- Allow different variables in association analysis to have different parameters (adapted from Ananth's changes, but tests still pass)
- Add hacky support for boolean vars (adapted from Ananth's changes)

- Code cleanup in association.R.  Rename variables to be more clear.
- Minor refactoring of decode_dist.R to resemble decode_assoc.R

