### PR TITLE
Addressing boolean RAPPOR decode failures when TRUE is ~ 0.

### DIFF
--- a/analysis/R/association.R
+++ b/analysis/R/association.R
@@ -104,6 +104,75 @@ GetOtherProbs <- function(counts, map_by_cohort, marginal, params, pstar,
   result
 }
 
+GetCondProbBooleanReports <- function(reports, pstar, qstar, num_cores) {
+  # Compute conditional probabilities given a set of Boolean reports.
+  #
+  # Args:
+  #   reports: RAPPOR reports as a list of bit arrays (of length 1, because
+  #   this is a boolean report)
+  #   pstar, qstar: standard params computed from from rappor parameters
+  #   num_cores: number of cores to pass to mclapply to parallelize apply
+  #
+  # Returns:
+  #   Conditional probability of all boolean reports corresponding to
+  #   candidates (TRUE, FALSE)
+
+  # The values below are p(report=1|value=TRUE), p(report=1|value=FALSE)
+  cond_probs_for_1 <- c(qstar, pstar)
+  # The values below are p(report=0|value=TRUE), p(report=0|value=FALSE)
+  cond_probs_for_0 <- c(1 - qstar,  1 - pstar)
+
+  cond_report_dist <- mclapply(reports, function(report) {
+    if (report[[1]] == 1) {
+      cond_probs_for_1
+    } else {
+      cond_probs_for_0
+    }
+  }, mc.cores = num_cores)
+  cond_report_dist
+}
+
+GetCondProbStringReports <- function(reports, cohorts, map, m, pstar, qstar,
+                                     marginal, prob_other = NULL, num_cores) {
+  # Wrapper around GetCondProb. Given a set of reports, cohorts, map and
+  # parameters m, p*, and q*, it first computes bit indices by cohort, and
+  # then applies GetCondProb individually to each report.
+  #
+  # Args:
+  #   reports: RAPPOR reports as a list of bit arrays
+  #   cohorts: cohorts corresponding to these reports as a list
+  #   map: map file
+  #   m, pstar, qstar: standard params computed from from rappor parameters
+  #   marginal: list containing marginal estimates (output of Decode)
+  #   prob_other: vector of length k, indicating how often each bit in the
+  #     Bloom filter was set by a string in the "other" category.
+  #
+  # Returns:
+  #   Conditional probability of all reports given each of the strings in
+  #   marginal$string
+
+  # Get bit indices that are set per candidate per cohort
+  bit_indices_by_cohort <- lapply(1:m, function(cohort) {
+    map_for_cohort <- map$map_by_cohort[[cohort]]
+    # Find the bits set by the candidate strings
+    bit_indices <- lapply(marginal$string, function(x) {
+      which(map_for_cohort[, x])
+    })
+    bit_indices
+  })
+
+  # Apply GetCondProb over all reports
+  cond_report_dist <- mclapply(seq(length(reports)), function(i) {
+    cohort <- cohorts[i]
+    #Log('Report %d, cohort %d', i, cohort)
+    bit_indices <- bit_indices_by_cohort[[cohort]]
+    GetCondProb(reports[[i]], pstar, qstar, bit_indices,
+                prob_other = prob_other[[cohort]])
+  }, mc.cores = num_cores)
+  cond_report_dist
+}
+
+
 GetCondProb <- function(report, pstar, qstar, bit_indices, prob_other = NULL) {
   # Given the observed bit array, estimate P(report | true value).
   # Probabilities are estimated for all truth values.
@@ -350,6 +419,8 @@ ComputeDistributionEM <- function(reports, report_cohorts, maps,
     p <- var_params$p
     q <- var_params$q
     f <- var_params$f
+    # pstar and qstar needed to compute other probabilities as well as for
+    # inputs to GetCondProb{Boolean, String}Reports subsequently
     pstar <- (1 - f / 2) * p + (f / 2) * q
     qstar <- (1 - f / 2) * q + (f / 2) * p
     k <- var_params$k
@@ -368,42 +439,18 @@ ComputeDistributionEM <- function(reports, report_cohorts, maps,
       found_strings[[j]] <- c(found_strings[[j]], "Other")
     }
 
-    bit_indices_by_cohort <- lapply(1:var_params$m, function(cohort) {
-      map_for_cohort <- var_map$map_by_cohort[[cohort]]
-      # Find the bits set by the candidate strings
-      bit_indices <- lapply(marginal$string, function(x) {
-        which(map_for_cohort[, x])
-      })
-      bit_indices
-    })
-
+    # Get the joint conditional distribution
     Log('\tGetCondProb for each report (%d cores)', num_cores)
 
-    # Get the joint conditional distribution
     # TODO(pseudorandom): check RAPPOR type more systematically instead of by
     # checking if k == 1
-    if(k == 1) {
-      # The candidate strings for Boolean are (TRUE, FALSE)
-      # The values below are p(report=1|value=TRUE), p(report=1|value=FALSE)
-      cond_probs_for_1 <- c(qstar, pstar)
-      # The values below are p(report=0|value=TRUE), p(report=0|value=FALSE)
-      cond_probs_for_0 <- c(1 - qstar,  1 - pstar)
-
-      cond_report_dist <- mclapply(var_report, function(report) {
-        if(report[[1]] == 1) {
-          cond_probs_for_1
-        } else {
-          cond_probs_for_0
-        }
-      }, mc.cores = num_cores)
+    if (k == 1) {
+      cond_report_dist <- GetCondProbBooleanReports(var_report, pstar, qstar,
+                                                    num_cores)
     } else {
-      cond_report_dist <- mclapply(seq(length(var_report)), function(i) {
-        cohort <- var_cohort[i]
-        #Log('Report %d, cohort %d', i, cohort)
-        bit_indices <- bit_indices_by_cohort[[cohort]]
-        GetCondProb(var_report[[i]], pstar, qstar, bit_indices,
-                    prob_other = prob_other[[cohort]])
-      }, mc.cores = num_cores)
+      cond_report_dist <- GetCondProbStringReports(var_report,
+                                var_cohort, var_map, var_params$m, pstar, qstar,
+                                marginal, prob_other, num_cores)
     }
 
     Log('\tUpdateJointConditional')

--- a/analysis/R/association.R
+++ b/analysis/R/association.R
@@ -356,7 +356,7 @@ ComputeDistributionEM <- function(reports, report_cohorts, maps,
 
     # Ignore other probability if either ignore_other is set or k == 1
     # (Boolean RAPPOR)
-    if (ignore_other || (k == 1)) {
+    if (ignore_other) {
       prob_other <- vector(mode = "list", length = var_params$m)
     } else {
       # Compute the probability of the "other" category

--- a/analysis/R/association.R
+++ b/analysis/R/association.R
@@ -380,10 +380,15 @@ ComputeDistributionEM <- function(reports, report_cohorts, maps,
     Log('\tGetCondProb for each report (%d cores)', num_cores)
 
     # Get the joint conditional distribution
+    # TODO(pseudorandom): check RAPPOR type more systematically instead of by
+    # checking if k == 1
     if(k == 1) {
-      # TRUE, FALSE
+      # The candidate strings for Boolean are (TRUE, FALSE)
+      # The values below are p(report=1|value=TRUE), p(report=1|value=FALSE)
       cond_probs_for_1 <- c(qstar, pstar)
+      # The values below are p(report=0|value=TRUE), p(report=0|value=FALSE)
       cond_probs_for_0 <- c(1 - qstar,  1 - pstar)
+
       cond_report_dist <- mclapply(var_report, function(report) {
         if(report[[1]] == 1) {
           cond_probs_for_1

--- a/analysis/R/association.R
+++ b/analysis/R/association.R
@@ -326,7 +326,6 @@ ComputeDistributionEM <- function(reports, report_cohorts, maps,
       var_params <- params_list[[j]]
     }
 
-    # Compute the probability of the "other" category
     var_counts <- NULL
     if (is.null(marginals)) {
       Log('\tSumming bits to gets observed counts')
@@ -353,10 +352,14 @@ ComputeDistributionEM <- function(reports, report_cohorts, maps,
     f <- var_params$f
     pstar <- (1 - f / 2) * p + (f / 2) * q
     qstar <- (1 - f / 2) * q + (f / 2) * p
+    k <- var_params$k
 
-    if (ignore_other) {
+    # Ignore other probability if either ignore_other is set or k == 1
+    # (Boolean RAPPOR)
+    if (ignore_other || (k == 1)) {
       prob_other <- vector(mode = "list", length = var_params$m)
     } else {
+      # Compute the probability of the "other" category
       if (is.null(var_counts)) {
         var_counts <- ComputeCounts(var_report, var_cohort, var_params)
       }

--- a/analysis/R/decode.R
+++ b/analysis/R/decode.R
@@ -291,15 +291,15 @@ Resample <- function(e) {
   summed_counts <- colSums(counts)  # sum counts across cohorts
   es <- EstimateBloomCounts(params, summed_counts)  # estimate boolean counts
 
-  est <- es$estimates[[1]]
+  ests <- es$estimates[[1]]
   std <- es$stds[[1]]
 
   fit <- data.frame(
            string         = c("TRUE", "FALSE"),
-           estimate       = c(est * num_reports,
-                              num_reports - est * num_reports),
+           estimate       = c(ests * num_reports,
+                              num_reports - ests * num_reports),
            std_error      = c(std * num_reports, std * num_reports),
-           proportion     = c(est, 1 - est),
+           proportion     = c(ests, 1 - ests),
            prop_std_error = c(std, std))
 
   low_95 <- fit$proportion - 1.96 * fit$prop_std_error

--- a/analysis/R/decode.R
+++ b/analysis/R/decode.R
@@ -297,11 +297,6 @@ Resample <- function(e) {
   colnames(fit) = c("string", "estimate", "std_error", "proportion",
                "prop_std_error", "prop_low_95", "prop_high_95")
 
-  # TODO(pseudorandom): Should eventually output a fit dataframe that has
-  # both TRUE and FALSE estimates. Currently only producing est for TRUE
-  # because association uses the Other algorithm to produce an estimate for
-  # FALSE.
-
   fit$string <- c("TRUE", "FALSE")
   fit$estimate <- c(es$estimates[[1]] * num_reports,
                     num_reports - es$estimates[[1]] * num_reports)
@@ -338,8 +333,6 @@ Decode <- function(counts, map, params, alpha = 0.05,
   N <- sum(counts[, 1])
   if (k == 1) {
     # Heuristic for boolean var.
-    # TODO(pseudorandom): incorporate this into larger plan of handling
-    # Boolean RAPPOR
     params$m = 1
     return(.DecodeBoolean(counts, params, N))
   }

--- a/analysis/R/decode_test.R
+++ b/analysis/R/decode_test.R
@@ -344,9 +344,9 @@ TestDecodeBool <- function() {
 }
 
 RunAll <- function() {
+  TestEstimateBloomCounts()
+  TestDecode()
   TestDecodeBool()
-  # TestEstimateBloomCounts()
-  # TestDecode()
 }
 
 RunAll()

--- a/analysis/R/decode_test.R
+++ b/analysis/R/decode_test.R
@@ -188,10 +188,17 @@ CheckDecodeHelper <- function(params, map, pdf, num_clients,
   decoded_partition <- setNames(decoded$fit$estimate, decoded$fit$string)
 
   checkTrue(L1Distance(decoded_partition, partition) < total^.5 * tolerance_l1,
-            "L1 distance is too large")
+            sprintf("L1 distance is too large: \
+                    L1Distance = %f, total^0.5 * tolerance_l1 = %f",
+                    L1Distance(decoded_partition, partition),
+                    total^0.5 * tolerance_l1))
 
   checkTrue(LInfDistance(decoded_partition, partition) <
-              max(partition)^.5 * tolerance_linf, "L_inf distance is too large")
+              max(partition)^.5 * tolerance_linf,
+              sprintf("L_inf distance is too large: \
+                      L1Distance = %f, max(partition)^0.5 * tolerance_linf = %f",
+                      L1Distance(decoded_partition, partition),
+                      max(partition)^0.5 * tolerance_linf))
 
   list(estimates = decoded_partition,
        stds = setNames(decoded$fit$std_error, decoded$fit$string))
@@ -242,6 +249,9 @@ TestDecode <- function() {
   # match the ground truth. Must be close enough though.
   noise0 <- list(p = 0, q = 1, f = 0)  # no noise whatsoever
 
+  # Args are: message str, test function, # repetitions,
+  #           params, map, true pdf, # clients,
+  #           tolerances
   CheckDecodeAveAndStds("Testing Decode (1/5)", CheckDecodeHelper, 100,
                         c(report4x2, noise0), map0, distribution0, 100,
                         tolerance_l1 = 5,
@@ -291,11 +301,43 @@ TestDecode <- function() {
                         c(report8x32, noise1), map2, distribution2, 10^6,
                         tolerance_l1 = values * 3,
                         tolerance_linf = 80)
+
+}
+
+TestDecodeBool <- function() {
+  # Testing Boolean Decode
+  values <- 2
+  # 1 bit; rest of the params don't matter
+  # setting up map_bool to be consistent with the Decode API and for
+  # GenerateCounts()
+  report_bool <- list(k = 1, m = 128, h = 2)
+  map_bool <- matrix(c(0, 1), nrow = 128 * 1, ncol = values, byrow = TRUE)
+
+  colnames(map_bool) <- c("FALSE", "TRUE")
+  distribution_bool <- ComputePdf("zipf1.5", values)
+  names(distribution_bool) <- colnames(map_bool)
+  noise2 <- list(p = 0.25, q = 0.75, f = 0.5)
+
+  # tolerance_l1 set to four standard deviations to avoid any flakiness in
+  # tests
+  CheckDecodeAveAndStds("Testing .DecodeBoolean (1/2)", CheckDecodeHelper, 100,
+                        c(report_bool, noise2), map_bool, distribution_bool,
+                        10^6,
+                        tolerance_l1 = 4 * values,
+                        tolerance_linf = 80)
+
+  noise1 <- list(p = .4, q = .6, f = .5)  # substantial noise, 7 stddevs error
+  CheckDecodeAveAndStds("Testing .DecodeBoolean (2/2)", CheckDecodeHelper, 100,
+                        c(report_bool, noise1), map_bool, distribution_bool,
+                        10^6,
+                        tolerance_l1 = 7 * values,
+                        tolerance_linf = 80)
 }
 
 RunAll <- function() {
   TestEstimateBloomCounts()
   TestDecode()
+  TestDecodeBool()
 }
 
 RunAll()

--- a/analysis/R/decode_test.R
+++ b/analysis/R/decode_test.R
@@ -320,24 +320,33 @@ TestDecodeBool <- function() {
 
   # tolerance_l1 set to four standard deviations to avoid any flakiness in
   # tests
-  CheckDecodeAveAndStds("Testing .DecodeBoolean (1/2)", CheckDecodeHelper, 100,
+  CheckDecodeAveAndStds("Testing .DecodeBoolean (1/3)", CheckDecodeHelper, 100,
                         c(report_bool, noise2), map_bool, distribution_bool,
                         10^6,
                         tolerance_l1 = 4 * values,
                         tolerance_linf = 80)
 
-  noise1 <- list(p = .4, q = .6, f = .5)  # substantial noise, 7 stddevs error
-  CheckDecodeAveAndStds("Testing .DecodeBoolean (2/2)", CheckDecodeHelper, 100,
+  noise1 <- list(p = .4, q = .6, f = .5)  # substantial noise => 7 stddevs error
+  CheckDecodeAveAndStds("Testing .DecodeBoolean (2/3)", CheckDecodeHelper, 100,
                         c(report_bool, noise1), map_bool, distribution_bool,
                         10^6,
                         tolerance_l1 = 7 * values,
                         tolerance_linf = 80)
+
+  distribution_near_zero <- c(0.999, 0.001)
+  names(distribution_near_zero) <- colnames(map_bool)
+
+  CheckDecodeAveAndStds("Testing .DecodeBoolean (3/3)", CheckDecodeHelper, 100,
+                        c(report_bool, noise2), map_bool,
+                        distribution_near_zero, 10^6,
+                        tolerance_l1 = 4 * values,
+                        tolerance_linf = 80)
 }
 
 RunAll <- function() {
-  TestEstimateBloomCounts()
-  TestDecode()
   TestDecodeBool()
+  # TestEstimateBloomCounts()
+  # TestDecode()
 }
 
 RunAll()

--- a/analysis/R/decode_test.R
+++ b/analysis/R/decode_test.R
@@ -234,7 +234,7 @@ TestDecode <- function() {
 
   # TOY TESTS: three values, 2 cohorts, 4 bits each
 
-  report4x2 <- list(k = 4, m = 2, h = 2)  # 2 cohorts, 4 bits each
+  params_4x2 <- list(k = 4, m = 2, h = 2)  # 2 cohorts, 4 bits each
   map0 <- Matrix(0, nrow = 8, ncol = 3, sparse = TRUE)  # 3 possible values
   map0[1,] <- c(1, 0, 0)
   map0[2,] <- c(0, 1, 0)
@@ -253,93 +253,95 @@ TestDecode <- function() {
   #           params, map, true pdf, # clients,
   #           tolerances
   CheckDecodeAveAndStds("Testing Decode (1/5)", CheckDecodeHelper, 100,
-                        c(report4x2, noise0), map0, distribution0, 100,
+                        c(params_4x2, noise0), map0, distribution0, 100,
                         tolerance_l1 = 5,
                         tolerance_linf = 3)
 
   noise1 <- list(p = .4, q = .6, f = .5)  # substantial noise, very few reports
   CheckDecodeAveAndStds("Testing Decode (2/5)", CheckDecodeHelper, 100,
-                        c(report4x2, noise1), map0, distribution0, 100,
+                        c(params_4x2, noise1), map0, distribution0, 100,
                         tolerance_l1 = 20,
                         tolerance_linf = 20)
 
   # substantial noise, many reports
   CheckDecodeAveAndStds("Testing Decode (3/5)", CheckDecodeHelper, 100,
-                        c(report4x2, noise1), map0, distribution0, 100000,
+                        c(params_4x2, noise1), map0, distribution0, 100000,
                         tolerance_l1 = 50,
                         tolerance_linf = 40)
 
   # MEDIUM TEST: 100 values, 32 cohorts, 8 bits each, 10^6 reports
-  values <- 100
+  num_values <- 100
 
-  report8x32 <- list(k = 8, m = 32, h = 2)  # 32 cohorts, 8 bits each
+  params_8x32 <- list(k = 8, m = 32, h = 2)  # 32 cohorts, 8 bits each
 
-  map1 <- matrix(rbinom(32 * 8 * values, 1, .25), nrow = 32 * 8, ncol = values)
+  map1 <- matrix(rbinom(32 * 8 * num_values, 1, .25), nrow = 32 * 8, ncol =
+                 num_values)
 
-  colnames(map1) <- sprintf("v%d", 1:values)
+  colnames(map1) <- sprintf("v%d", 1:num_values)
 
-  distribution1 <- ComputePdf("zipf1", values)
+  distribution1 <- ComputePdf("zipf1", num_values)
   names(distribution1) <- colnames(map1)
   CheckDecodeAveAndStds("Testing Decode (4/5)", CheckDecodeHelper, 100,
-                        c(report8x32, noise1), map1, distribution1, 10^6,
-                        tolerance_l1 = values * 3,
+                        c(params_8x32, noise1), map1, distribution1, 10^6,
+                        tolerance_l1 = num_values * 3,
                         tolerance_linf = 100)
 
   # Testing LASSO: 500 values, 32 cohorts, 8 bits each, 10^6 reports
-  values <- 500
+  num_values <- 500
 
-  report8x32 <- list(k = 8, m = 32, h = 2)  # 32 cohorts, 8 bits each
+  params_8x32 <- list(k = 8, m = 32, h = 2)  # 32 cohorts, 8 bits each
 
-  map2 <- matrix(rbinom(32 * 8 * values, 1, .25), nrow = 32 * 8, ncol = values)
+  map2 <- matrix(rbinom(32 * 8 * num_values, 1, .25), nrow = 32 * 8, ncol =
+                 num_values)
 
-  colnames(map2) <- sprintf("v%d", 1:values)
+  colnames(map2) <- sprintf("v%d", 1:num_values)
 
-  distribution2 <- ComputePdf("zipf1.5", values)
+  distribution2 <- ComputePdf("zipf1.5", num_values)
   names(distribution2) <- colnames(map2)
 
   CheckDecodeAveAndStds("Testing Decode (5/5)", CheckDecodeHelper, 1,
-                        c(report8x32, noise1), map2, distribution2, 10^6,
-                        tolerance_l1 = values * 3,
+                        c(params_8x32, noise1), map2, distribution2, 10^6,
+                        tolerance_l1 = num_values * 3,
                         tolerance_linf = 80)
 
 }
 
 TestDecodeBool <- function() {
   # Testing Boolean Decode
-  values <- 2
+  num_values <- 2
   # 1 bit; rest of the params don't matter
+  params_bool <- list(k = 1, m = 128, h = 2)
   # setting up map_bool to be consistent with the Decode API and for
   # GenerateCounts()
-  report_bool <- list(k = 1, m = 128, h = 2)
-  map_bool <- matrix(c(0, 1), nrow = 128 * 1, ncol = values, byrow = TRUE)
+  map_bool <- matrix(c(0, 1), nrow = 128 * 1, ncol = num_values, byrow = TRUE)
 
   colnames(map_bool) <- c("FALSE", "TRUE")
-  distribution_bool <- ComputePdf("zipf1.5", values)
+  distribution_bool <- ComputePdf("zipf1.5", num_values)
   names(distribution_bool) <- colnames(map_bool)
   noise2 <- list(p = 0.25, q = 0.75, f = 0.5)
 
   # tolerance_l1 set to four standard deviations to avoid any flakiness in
   # tests
   CheckDecodeAveAndStds("Testing .DecodeBoolean (1/3)", CheckDecodeHelper, 100,
-                        c(report_bool, noise2), map_bool, distribution_bool,
+                        c(params_bool, noise2), map_bool, distribution_bool,
                         10^6,
-                        tolerance_l1 = 4 * values,
+                        tolerance_l1 = 4 * num_values,
                         tolerance_linf = 80)
 
   noise1 <- list(p = .4, q = .6, f = .5)  # substantial noise => 7 stddevs error
   CheckDecodeAveAndStds("Testing .DecodeBoolean (2/3)", CheckDecodeHelper, 100,
-                        c(report_bool, noise1), map_bool, distribution_bool,
+                        c(params_bool, noise1), map_bool, distribution_bool,
                         10^6,
-                        tolerance_l1 = 7 * values,
+                        tolerance_l1 = 7 * num_values,
                         tolerance_linf = 80)
 
   distribution_near_zero <- c(0.999, 0.001)
   names(distribution_near_zero) <- colnames(map_bool)
 
   CheckDecodeAveAndStds("Testing .DecodeBoolean (3/3)", CheckDecodeHelper, 100,
-                        c(report_bool, noise2), map_bool,
+                        c(params_bool, noise2), map_bool,
                         distribution_near_zero, 10^6,
-                        tolerance_l1 = 4 * values,
+                        tolerance_l1 = 4 * num_values,
                         tolerance_linf = 80)
 }
 

--- a/analysis/cpp/fast_em.cc
+++ b/analysis/cpp/fast_em.cc
@@ -142,7 +142,11 @@ static void ExpectationMaximization(
   log("Starting %d EM iterations", max_em_iters);
 
   for (int em_iter = 0; em_iter < max_em_iters; ++em_iter) {
-    log("fast_em iteration %d", em_iter);
+
+    if(em_iter % 200 == 0) {
+      log("fast_em iteration %d", em_iter);
+    }
+
     //
     // lapply() step.
     //
@@ -179,7 +183,8 @@ static void ExpectationMaximization(
       new_pij[i] /= num_entries;
     }
 
-    PrintPij(new_pij);
+    // TODO(pseudorandom): include verbose mode where this is printed
+    // PrintPij(new_pij);
 
     //
     // Check for termination
@@ -194,7 +199,10 @@ static void ExpectationMaximization(
 
     pij = new_pij;  // copy
 
-    log("max_dif: %e", em_iter, max_dif);
+    if (em_iter % 200 == 0) {
+      PrintPij(new_pij);
+      log("max_dif: %e", em_iter, max_dif);
+    }
 
     if (max_dif < epsilon) {
       log("Early EM termination: %e < %e", max_dif, epsilon);

--- a/analysis/cpp/fast_em.cc
+++ b/analysis/cpp/fast_em.cc
@@ -142,11 +142,7 @@ static void ExpectationMaximization(
   log("Starting %d EM iterations", max_em_iters);
 
   for (int em_iter = 0; em_iter < max_em_iters; ++em_iter) {
-
-    if(em_iter % 200 == 0) {
-      log("fast_em iteration %d", em_iter);
-    }
-
+    log("fast_em iteration %d", em_iter);
     //
     // lapply() step.
     //
@@ -183,8 +179,7 @@ static void ExpectationMaximization(
       new_pij[i] /= num_entries;
     }
 
-    // TODO(pseudorandom): include verbose mode where this is printed
-    // PrintPij(new_pij);
+    PrintPij(new_pij);
 
     //
     // Check for termination
@@ -199,10 +194,7 @@ static void ExpectationMaximization(
 
     pij = new_pij;  // copy
 
-    if (em_iter % 200 == 0) {
-      PrintPij(new_pij);
-      log("max_dif: %e", em_iter, max_dif);
-    }
+    log("max_dif: %e", em_iter, max_dif);
 
     if (max_dif < epsilon) {
       log("Early EM termination: %e < %e", max_dif, epsilon);

--- a/bin/decode_assoc.R
+++ b/bin/decode_assoc.R
@@ -181,10 +181,11 @@ ResultMatrixToDataFrame <- function(m, string_var_name, bool_var_name) {
   dim_names <- list()
   # First dimension is bool.  TODO: Remove this once we're not using
   # --create-bool-map.
-  dim_names[[bool_var_name]] <- c('TRUE', 'FALSE')
-  dim_names[[string_var_name]] <- dimnames(m)[[2]]
+  # dim_names[[bool_var_name]] <- c('TRUE', 'FALSE')
+  # dim_names[[string_var_name]] <- dimnames(m)[[2]]
 
-  dimnames(m) <- dim_names
+  # dimnames(m) <- dim_names
+
   # http://stackoverflow.com/questions/15885111/create-data-frame-from-a-matrix-in-r
   fit_df <- as.data.frame(as.table(m))
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -69,8 +69,9 @@ EOF
   local prob_q=0.75
   local prob_f=0.5
 
-  # 7 items in the input.  7000 items is enough.
-  local assoc_testdata_count=1000
+  # 10 items in the input. 50,000 items is enough to eyeball accuracy of
+  # results.
+  local assoc_testdata_count=5000
 
   PYTHONPATH=../client/python \
     ../tests/rappor_sim.py \
@@ -149,7 +150,7 @@ decode-assoc() {
   # Printing true results to compare against
   echo
   echo "==> _tmp/true_values.csv <=="
-  head _tmp/true_values.csv
+  cat _tmp/true_values.csv
 }
 
 decode-assoc-bad-rows() {

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -51,6 +51,9 @@ write-assoc-testdata() {
 domain,flag..HTTPS
 google.com,1
 google.com,1
+google.com,1
+google.com,1
+google.com,0
 yahoo.com,1
 yahoo.com,0
 bing.com,1
@@ -135,13 +138,18 @@ decode-assoc() {
     --var2 flag..HTTPS \
     --map1 _tmp/domain_map.csv \
     --create-bool-map \
-    --max-em-iters 10 \
+    --max-em-iters 1000 \
     --num-cores 2 \
     --output-dir _tmp \
     --tmp-dir _tmp \
     "$@"
 
   head _tmp/assoc-*
+
+  # Printing true results to compare against
+  echo
+  echo "==> _tmp/true_values.csv <=="
+  head _tmp/true_values.csv
 }
 
 decode-assoc-bad-rows() {


### PR DESCRIPTION
New function .DecodeBoolean outputs an estimate for TRUE directly from EstimateBloomCounts; bypassing maps and LASSO.

This fixes a few errors that arise when the underlying distribution for TRUE is very close
to zero and maps + LASSO fails to recover "a candidate solution."

- Updated decode.R with a new private function .DecodeBoolean to decode when inputs are boolean
- Updated decode_test.R with tests to check .DecodeBoolean
- decode_assoc.R now does not use the Other category when analyzing boolean rappor inputs (k==1)
- decode_test.R helper functions now output a little more information when test fails.