### PR TITLE
Fix non-deterministic map matrix dimension bug that causes bad Decode().

### DIFF
--- a/analysis/R/decode.R
+++ b/analysis/R/decode.R
@@ -312,8 +312,39 @@ Resample <- function(e) {
   return(list(fit = fit))
 }
 
+CheckDecodeInputs <- function(counts, map, params) {
+  # Returns an error message, or NULL if there is no error.
+
+  if (nrow(map) != (params$m * params$k)) {
+    return(sprintf(
+        "Map matrix has invalid dimensions: m * k = %d, nrow(map) = %d",
+        params$m * params$k, nrow(map)))
+  }
+
+  if ((ncol(counts) - 1) != params$k) {
+    return(sprintf(paste0(
+        "Dimensions of counts file do not match: m = %d, k = %d, ",
+        "nrow(counts) = %d, ncol(counts) = %d"), params$m, params$k,
+        nrow(counts), ncol(counts)))
+
+  }
+
+  # numerically correct comparison
+  if (isTRUE(all.equal((1 - params$f) * (params$p - params$q), 0))) {
+    return("Information is lost. Cannot decode.")
+  }
+
+  return(NULL)  # no error
+}
+
 Decode <- function(counts, map, params, alpha = 0.05,
                    correction = c("Bonferroni"), quiet = FALSE, ...) {
+
+  error_msg <- CheckDecodeInputs(counts, map, params)
+  if (!is.null(error_msg)) {
+    stop(error_msg)
+  }
+
   k <- params$k
   p <- params$p
   q <- params$q

--- a/analysis/R/read_input.R
+++ b/analysis/R/read_input.R
@@ -40,22 +40,20 @@ ReadParameterFile <- function(params_file) {
   params
 }
 
-ReadCountsFile <- function(counts_file, params = NULL) {
+ReadCountsFile <- function(counts_file, params) {
   # Read in the counts file.
   if (!file.exists(counts_file)) {
     return(NULL)
   }
   counts <- read.csv(counts_file, header = FALSE)
 
-  if (!is.null(params)) {
-    if (nrow(counts) != params$m) {
-      stop("Counts file: number of rows should equal number of cohorts (m).")
-    }
+  if (nrow(counts) != params$m) {
+    stop("Counts file: number of rows should equal number of cohorts (m).")
+  }
 
-    if ((ncol(counts) - 1) != params$k) {
-      stop(paste0("Counts file: number of columns should equal to k + 1: ",
-                  ncol(counts)))
-    }
+  if ((ncol(counts) - 1) != params$k) {
+    stop(paste0("Counts file: number of columns should equal to k + 1: ",
+                ncol(counts)))
   }
 
   if (any(counts < 0)) {

--- a/bin/decode_assoc.R
+++ b/bin/decode_assoc.R
@@ -133,14 +133,19 @@ source.rappor("analysis/R/util.R")
 options(stringsAsFactors = FALSE)
 options(max.print = 100)  # So our structure() debug calls look better
 
-# Processes the maps loaded using ReadMapFile and turns it into something that
-# association.R can use.  Namely, we want a map per cohort.
-#
-# Arguments:
-#   map: map object as parsed by ReadMapFile (i.e. has map$map member)
-#   k: report width in bits
-CreateAssocStringMap <- function(map, params) {
-  all_cohorts_map <- map$map
+CreateAssocStringMap <- function(all_cohorts_map, params) {
+  # Processes the maps loaded using ReadMapFile and turns it into something
+  # that association.R can use.  Namely, we want a map per cohort.
+  #
+  # Arguments:
+  #   all_cohorts_map: map matrix, as for single variable analysis
+  #   params: encoding parameters
+
+  if (nrow(all_cohorts_map) != (params$m * params$k)) {
+    stop(sprintf(
+        "Map matrix has invalid dimensions: m * k = %d, nrow(map) = %d",
+        params$m * params$k, nrow(all_cohorts_map)))
+  }
 
   k <- params$k
   map_by_cohort <- lapply(0 : (params$m-1), function(cohort) {
@@ -244,7 +249,10 @@ main <- function(opts) {
     UsageError("--map1 must be provided when --var1 is a string (var = %s)",
                opts$var1)
   }
-  LoadMapFile(opts$map1)
+
+  string_params <- params
+  LoadMapFile(opts$map1, string_params)
+
   # for 100k map file: 31 seconds to load map and write cache; 2.2 seconds to
   # read cache
   # LoadMapFile has the side effect of putting 'map' in the global enviroment.
@@ -309,9 +317,6 @@ main <- function(opts) {
   # NOTE: Basic RAPPOR doesn't need cohorts.
   cohorts_list <- rep(list(cohorts), num_vars)
 
-  # i.e. create a list of length 2, with identical cohorts.
-  string_params <- params
-
   # TODO: We should use the closed-form formulas rather than calling the
   # solver, and not require this flag.
   if (!opts$create_bool_map) {
@@ -326,7 +331,7 @@ main <- function(opts) {
   params_list <- list(bool_params, string_params)
 
   Log('CreateAssocStringMap')
-  string_map <- CreateAssocStringMap(map, params)
+  string_map <- CreateAssocStringMap(map$map, params)
 
   Log('CreateAssocBoolMap')
   bool_map <- CreateAssocBoolMap(params)

--- a/bin/decode_dist.R
+++ b/bin/decode_dist.R
@@ -92,7 +92,7 @@ main <- function(opts) {
 
   # Run a single model of all inputs are specified.
   params <- ReadParameterFile(opts$params)
-  counts <- ReadCountsFile(opts$counts)
+  counts <- ReadCountsFile(opts$counts, params)
 
   # Count BEFORE adjustment.
   num_reports <- sum(counts[, 1])

--- a/bin/decode_dist.R
+++ b/bin/decode_dist.R
@@ -83,34 +83,6 @@ AdjustCounts <- function(counts, params) {
   })
 }
 
-ValidateInput <- function(params, counts, map) {
-  val <- "valid"
-  if (is.null(counts)) {
-    val <- "No counts file found. Skipping"
-    return(val)
-  }
-
-  if (nrow(map) != (params$m * params$k)) {
-    val <- paste("Map does not match the counts file!",
-                 "mk = ", params$m * params$k,
-                 "nrow(map):", nrow(map),
-                 collapse = " ")
-  }
-
-  if ((ncol(counts) - 1) != params$k) {
-    val <- paste("Dimensions of counts file do not match:",
-                 "m =", params$m, "counts rows: ", nrow(counts),
-                 "k =", params$k, "counts cols: ", ncol(counts) - 1,
-                 collapse = " ")
-  }
-
-  # numerically correct comparison
-  if(isTRUE(all.equal((1 - params$f) * (params$p - params$q), 0)))
-    stop("Information is lost. Cannot decode.")
-
-  val
-}
-
 main <- function(opts) {
   Log("decode-dist")
   Log("argv:")
@@ -127,17 +99,11 @@ main <- function(opts) {
 
   counts <- AdjustCounts(counts, params)
 
-  LoadMapFile(opts$map)
-
-  val <- ValidateInput(params, counts, map$map)  # NOTE: using global map
-  if (val != "valid") {
-    Log("ERROR: Invalid input: %s", val)
-    quit(status = 1)
-  }
+  LoadMapFile(opts$map, params)
 
   Log("Decoding %d reports", num_reports)
-  res <- Decode(counts, map$map, params, correction = opts$correction, alpha =
-                opts$alpha)
+  res <- Decode(counts, map$map, params, correction = opts$correction,
+                alpha = opts$alpha)
   Log("Done decoding")
 
   if (nrow(res$fit) == 0) {

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -54,7 +54,7 @@ decode-assoc-help() {
 # Clear the R cache for the map files.
 clear-cached-files() {
   local dir=$1
-  find $dir -name '*.rda' | xargs rm --verbose
+  find $dir -name '*.rda' | xargs --no-run-if-empty -- rm --verbose
 }
 
 write-assoc-testdata() {

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -69,7 +69,7 @@ bing.com,0
 EOF
 
   local num_bits=8
-  local num_hashes=2
+  local num_hashes=1
   local num_cohorts=128
 
   local prob_p=0.25

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -51,8 +51,16 @@ decode-assoc-help() {
   time $RAPPOR_SRC/bin/decode-assoc --help
 }
 
+# Clear the R cache for the map files.
+clear-cached-files() {
+  local dir=$1
+  find $dir -name '*.rda' | xargs rm --verbose
+}
+
 write-assoc-testdata() {
   mkdir -p _tmp
+
+  clear-cached-files _tmp
 
   cat >_tmp/true_values.csv <<EOF 
 domain,flag..HTTPS

--- a/tests/compare_dist.R
+++ b/tests/compare_dist.R
@@ -77,10 +77,11 @@ RunRappor <- function(prefix_case, prefix_instance, ctx) {
   #    ctx: context file with params field filled in
 
   c <- paste0(prefix_instance, '_counts.csv')
-  counts <- ReadCountsFile(c)
+  counts <- ReadCountsFile(c, ctx$params)
 
   m <- paste0(prefix_case, '_map.csv')
-  map <- ReadMapFile(m)  # Switch to LoadMapFile if want to cache the result
+  # Switch to LoadMapFile if want to cache the result
+  map <- ReadMapFile(m, ctx$params)
 
   # Main decode.R API
   timing <- system.time({

--- a/tests/rappor_sim.py
+++ b/tests/rappor_sim.py
@@ -111,7 +111,8 @@ def GenAssocTestdata(params1, params2, irr_rand, assoc_testdata_count,
   for i in xrange(n):
     for v1, v2 in rows:
       client_str = 'c%d' % report_index
-      cohort = report_index % params1.num_cohorts
+      # randint(a, b) gives i such that a <= i <= b
+      cohort = random.randint(0, params1.num_cohorts - 1)
 
       string_encoder = rappor.Encoder(params1, cohort, client_str, irr_rand)
       bool_encoder = rappor.Encoder(params2, cohort, client_str, irr_rand)


### PR DESCRIPTION
- bin/test.sh: Change to h=1 to trigger the bug more reliably
- move validation of inputs to Decode(), instead of decode_dist.R, so we
  get it whenever we call Decode()
- Check dimensions in CreateAssocStringMap, for a better error message
- Require 'params' when calling ReadMapFile/LoadMapFile, so the bug can't happen in the first place
- Log a message when entries are removed from the map