### PR TITLE
Fix fastrand bug when p1 = 1.0.  int was overflowing.

### DIFF
--- a/client/python/_fastrand.c
+++ b/client/python/_fastrand.c
@@ -38,14 +38,16 @@ uint64_t randbits(float p1, int num_bits) {
   uint64_t result = 0;
   // RAND_MAX is the maximum int returned by rand().
   //
-  // When p1 == 1.0, we to guarantee that all bits are 1.  In the rare case
-  // that rand() returns RAND_MAX, it will be strictly less than 'threshold',
-  // so we get 1.  (RAND_MAX is an int so it won't overflow a uint64_t.)
+  // When p1 == 1.0, we want to guarantee that all bits are 1.  The threshold
+  // will be RAND_MAX + 1.  In the rare case that rand() returns RAND_MAX, the
+  // "<" test succeeds, so we get 1.
   //
   // When p1 == 0.0, we want to guarantee that all bits are 0.  The threshold
-  // will be 0.  If rand() returns 0, then the "<" test fails, so we get 0.
+  // will be 0.  In the rare case that rand() returns 0, the "<" test fails, so
+  // we get 0.
 
   // NOTE: cast is necessary to do unsigned arithmetic rather than signed.
+  // RAND_MAX is an int so adding 1 won't overflow a uint64_t.
   uint64_t max = (uint64_t)RAND_MAX + 1u;
   uint64_t threshold = p1 * max;
   int i;

--- a/client/python/_fastrand.c
+++ b/client/python/_fastrand.c
@@ -36,10 +36,12 @@ limitations under the License.
 
 uint64_t randbits(float p1, int num_bits) {
   uint64_t result = 0;
-  int threshold = (int)(p1 * RAND_MAX);
+  uint64_t threshold = p1 * RAND_MAX;
   int i;
   for (i = 0; i < num_bits; ++i) {
-    uint64_t bit = (rand() < threshold);
+    // NOTE: The comparison is <= so that p1 = 1.0 implies that the bit is
+    // ALWAYS set.  RAND_MAX is the maximum value returned by rand().
+    uint64_t bit = (rand() <= threshold);
     result |= (bit << i);
   }
   return result;

--- a/client/python/_fastrand.c
+++ b/client/python/_fastrand.c
@@ -36,12 +36,23 @@ limitations under the License.
 
 uint64_t randbits(float p1, int num_bits) {
   uint64_t result = 0;
-  uint64_t threshold = p1 * RAND_MAX;
+  // RAND_MAX is the maximum int returned by rand().
+  //
+  // When p1 == 1.0, we to guarantee that all bits are 1.  In the rare case
+  // that rand() returns RAND_MAX, it will be strictly less than 'threshold',
+  // so we get 1.  (RAND_MAX is an int so it won't overflow a uint64_t.)
+  //
+  // When p1 == 0.0, we want to guarantee that all bits are 0.  The threshold
+  // will be 0.  If rand() returns 0, then the "<" test fails, so we get 0.
+
+  // NOTE: cast is necessary to do unsigned arithmetic rather than signed.
+  uint64_t max = (uint64_t)RAND_MAX + 1u;
+  uint64_t threshold = p1 * max;
   int i;
   for (i = 0; i < num_bits; ++i) {
     // NOTE: The comparison is <= so that p1 = 1.0 implies that the bit is
     // ALWAYS set.  RAND_MAX is the maximum value returned by rand().
-    uint64_t bit = (rand() <= threshold);
+    uint64_t bit = (rand() < threshold);
     result |= (bit << i);
   }
   return result;

--- a/client/python/fastrand_test.py
+++ b/client/python/fastrand_test.py
@@ -23,10 +23,13 @@ import unittest
 import _fastrand  # module under test
 
 
+BIT_WIDTHS = [8, 16, 32, 64]
+
+
 class FastRandTest(unittest.TestCase):
 
   def testRandbits64(self):
-    for n in [8, 16, 32, 64]:
+    for n in BIT_WIDTHS:
       #print '== %d' % n
       for p1 in [0.1, 0.5, 0.9]:
         #print '-- %f' % p1
@@ -39,6 +42,16 @@ class FastRandTest(unittest.TestCase):
           #b = bin(r)
           #print b
           #print b.count('1')
+
+
+  def testRandbits64_EdgeCases(self):
+    for n in BIT_WIDTHS:
+      r = _fastrand.randbits(0.0, n)
+      self.assertEqual(0, r)
+
+    for n in BIT_WIDTHS:
+      r = _fastrand.randbits(1.0, n)
+      self.assertEqual(2 ** n - 1, r)
 
   def testRandbitsError(self):
     r = _fastrand.randbits(-1, 64)

--- a/test.sh
+++ b/test.sh
@@ -37,17 +37,28 @@ readonly CLIENT_DIR=$REPO_ROOT/client/python
 # Fully Automated Tests
 #
 
-# Python unit tests.
+# Run all Python unit tests.
+#
+# Or pass a particular test to run with the correct PYTHONPATH, e.g.
+#
+# $ ./test.sh py-unit client/python/fastrand_test.py
 #
 # TODO: Separate out deterministic tests from statistical tests (which may
 # rarely fail)
 py-unit() {
   export PYTHONPATH=$CLIENT_DIR  # to find client library
 
-  set +o errexit
-  # -e: exit at first failure
-  find $REPO_ROOT -name \*_test.py | sh -x -e
+  if test $# -gt 0; then
+    "$@"
+  else
+    set +o errexit
+
+    # -e: exit at first failure
+    find $REPO_ROOT -name \*_test.py | sh -x -e
+  fi
+
   local exit_code=$?
+
   if test $exit_code -eq 0; then
     echo 'ALL TESTS PASSED'
   else


### PR DESCRIPTION
Add the ability to run an individual Python test with the right
PYTHONPATH.