### PR TITLE
Add a --use-map-cache flag to bin/decode-dist and bin/decode-assoc.

### DIFF
--- a/analysis/R/read_input.R
+++ b/analysis/R/read_input.R
@@ -66,6 +66,8 @@ ReadCountsFile <- function(counts_file, params) {
 }
 
 ReadMapFile <- function(map_file, params) {
+  Log("Parsing %s", map_file)
+
   # Read in the map file which is in the following format (two hash functions):
   # str1, h11, h12, h21 + k, h22 + k, h31 + 2k, h32 + 2k ...
   # str2, ...
@@ -117,7 +119,6 @@ LoadMapFile <- function(map_file, params) {
 
   # First save to a temp file, and then atomically rename to the destination.
   if (!file.exists(rda_path)) {
-    Log("Reading %s", map_file)
     map <- ReadMapFile(map_file, params)
 
     Log("Saving %s as an rda file for faster access", map_file)

--- a/bin/decode_assoc.R
+++ b/bin/decode_assoc.R
@@ -50,6 +50,10 @@ option_list <- list(
         help="Output directory (default .)"),
 
     make_option(
+        "--use-map-cache", dest="use_map_cache", default=FALSE,
+        action="store_true",
+        help="Cache map .csv files as .rda for faster startup."),
+    make_option(
         "--create-bool-map", dest="create_bool_map", default=FALSE,
         action="store_true",
         help="Hack to use string RAPPOR to analyze boolean variables."),
@@ -251,11 +255,14 @@ main <- function(opts) {
   }
 
   string_params <- params
-  LoadMapFile(opts$map1, string_params)
 
-  # for 100k map file: 31 seconds to load map and write cache; 2.2 seconds to
-  # read cache
-  # LoadMapFile has the side effect of putting 'map' in the global enviroment.
+  # Speedup for 100k map file: 31 seconds to load map and write cache; 2.2
+  # seconds to read .rda cache.
+  if (opts$use_map_cache) {
+    map <- LoadMapFile(opts$map1, string_params)
+  } else {
+    map <- ReadMapFile(opts$map1, string_params)
+  }
 
   # Important: first column is cohort (integer); the rest are variables, which
   # are ASCII bit strings.

--- a/bin/decode_dist.R
+++ b/bin/decode_dist.R
@@ -26,7 +26,12 @@ option_list <- list(
               help="Output directory (default .)"),
 
   make_option("--correction", default="FDR", help="Correction method"),
-  make_option("--alpha", default=.05, help="Alpha level")
+  make_option("--alpha", default=.05, help="Alpha level"),
+
+  make_option(
+      "--use-map-cache", dest="use_map_cache", default=FALSE,
+      action="store_true",
+      help="Cache map .csv files as .rda for faster startup.")
 )
 
 ParseOptions <- function() {
@@ -99,7 +104,11 @@ main <- function(opts) {
 
   counts <- AdjustCounts(counts, params)
 
-  LoadMapFile(opts$map, params)
+  if (opts$use_map_cache) {
+    map <- LoadMapFile(opts$map, params)
+  } else {
+    map <- ReadMapFile(opts$map, params)
+  }
 
   Log("Decoding %d reports", num_reports)
   res <- Decode(counts, map$map, params, correction = opts$correction,


### PR DESCRIPTION
The default is false, so you now have to explicitly enable it.  This is
better for tests, and also allows the file system where map files are
stored to be read-only.