### PR TITLE
Fix AdjustCounts() now that we always check the counts file dimensions.

### DIFF
--- a/pipeline/dist.sh
+++ b/pipeline/dist.sh
@@ -56,11 +56,11 @@ decode-dist-one() {
           --counts $counts \
           --params $params \
           --map $map \
-          --output-dir $task_dir
+          --output-dir $task_dir \
+          --adjust-counts-hack
   } >$log_file 2>&1
 
-  # TODO: set output name instead of dir?
-  # Right now it's the only CSV file.
+  # TODO: Don't pass --adjust-counts-hack unless the user asks for it.
 }
 
 # Print the number of processes to use.


### PR DESCRIPTION
Commit 6c3637d3e7ef74e371e62b860f03809a28e1aa89 made the input more
strict, but it broke AdjustCounts().

Now it's been moved to read_input.R, and you have to pass
--adjust-counts-hack to enable it.  By default, we should warn about
incorrect input dimensions.