### PR TITLE
Support arbitrary length bit strings

### DIFF
--- a/client/cpp/Makefile
+++ b/client/cpp/Makefile
@@ -143,6 +143,10 @@ _tmp/openssl_hash_impl_test : \
 		-lcrypto \
 		-g
 
+# Unittests are currently run manually, and require the Google gtest
+# framework version 1.7.0 or greater, found at
+#   https://github.com/google/googletest/releases
+# TODO(mdeshon-google): Installer script
 unittest: _tmp/openssl_hash_impl_unittest _tmp/encoder_unittest
 	_tmp/openssl_hash_impl_unittest
 	_tmp/encoder_unittest

--- a/client/cpp/Makefile
+++ b/client/cpp/Makefile
@@ -143,8 +143,12 @@ _tmp/openssl_hash_impl_test : \
 		-lcrypto \
 		-g
 
-unittest: _tmp/openssl_hash_impl_unittest
+unittest: _tmp/openssl_hash_impl_unittest _tmp/encoder_unittest
+	_tmp/openssl_hash_impl_unittest
+	_tmp/encoder_unittest
 
 _tmp/openssl_hash_impl_unittest: openssl_hash_impl_unittest.cc openssl_hash_impl.cc
-	$(CXX) -o $@  $^ -lssl -lcrypto -lgtest
-	$@
+	$(CXX) -g -o $@  $^ -lssl -lcrypto -lgtest
+
+_tmp/encoder_unittest: encoder_unittest.cc encoder.cc unix_kernel_rand_impl.cc openssl_hash_impl.cc
+	$(CXX) -g -o $@  $^ -lssl -lcrypto -lgtest

--- a/client/cpp/encoder.h
+++ b/client/cpp/encoder.h
@@ -94,6 +94,9 @@ class Encoder {
   // Encode a string, setting output parameter irr_out.  Only valid when the
   // return value is 'true' (success).
   bool EncodeString(const std::string& value, Bits* irr_out) const;
+  // For use with HmacDrbg hash function and any num_bits divisible by 8.
+  bool EncodeString(const std::string& value,
+                    std::vector<uint8_t>* irr_out) const;
 
   // For testing/simulation use only.
   bool _EncodeBitsInternal(const Bits bits, Bits* prr_out, Bits* irr_out)
@@ -103,9 +106,13 @@ class Encoder {
 
   // Accessor for the assigned cohort.
   uint32_t cohort() { return cohort_; }
+  // Set a cohort manually, if previously generated.
+  void set_cohort(uint32_t cohort);
 
  private:
   bool MakeBloomFilter(const std::string& value, Bits* bloom_out) const;
+  bool MakeBloomFilter(const std::string& value,
+                       std::vector<uint8_t>* bloom_out) const;
   bool GetPrrMasks(const Bits bits, Bits* uniform, Bits* f_mask) const;
 
   // static helper function for initialization
@@ -114,8 +121,8 @@ class Encoder {
   const std::string encoder_id_;
   const Params& params_;
   const Deps& deps_;
-  const uint32_t cohort_;
-  const std::string cohort_str_;
+  uint32_t cohort_;
+  std::string cohort_str_;
 };
 
 }  // namespace rappor

--- a/client/cpp/encoder_unittest.cc
+++ b/client/cpp/encoder_unittest.cc
@@ -1,0 +1,182 @@
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+#include "encoder.h"
+#include "openssl_hash_impl.h"
+#include "unix_kernel_rand_impl.h"
+
+   // We need the same "random" inputs to the IRR
+   // each time to have reproducible tests.
+FILE* mock_urandom(void) {
+ int i;
+ FILE *fp;
+ fp = tmpfile();
+ for (i = 0; i < 1024; i++) {
+   fputc((i * 17) % 256, fp);
+ }
+ fflush(fp);
+ fp = freopen(NULL, "r", fp);
+ return fp;
+}
+
+class EncoderTest : public ::testing::Test {
+  protected:
+   EncoderTest() {
+      encoder_id = std::string("metric-name").c_str();
+      fp = mock_urandom();
+      irr_rand = new rappor::UnixKernelRand(fp);
+   }
+
+   virtual ~EncoderTest() {
+     fclose(fp);
+     delete irr_rand;
+     delete deps;
+     delete params;
+     delete encoder;
+   }
+
+
+   FILE* fp;
+   const char* encoder_id;
+   rappor::UnixKernelRand *irr_rand;
+   rappor::Deps *deps;
+   rappor::Params *params;
+   rappor::Encoder *encoder;
+   rappor::Bits bits_out;
+   std::vector<uint8_t> bits_vector;
+};
+
+// Uses HmacSha256 and 32-bit outputs.
+class EncoderUint32Test : public EncoderTest {
+  protected:
+   EncoderUint32Test() {
+     deps = new rappor::Deps(rappor::Md5, "client-secret", rappor::HmacSha256,
+                             *irr_rand);
+     params = new rappor::Params(32,    // num_bits (k)
+                                 2,     // num_hashes (h)
+                                 128,   // num_cohorts (m)
+                                 0.25,  // probability f for PRR
+                                 0.75,  // probability p for IRR
+                                 0.5);  // probability q for IRR
+     encoder = new rappor::Encoder(encoder_id, *params, *deps);
+
+   }
+};
+
+// Uses HmacDrbg and variable-size vector outputs.
+class EncoderUnlimTest : public EncoderTest {
+ protected:
+  EncoderUnlimTest() {
+    deps = new rappor::Deps(rappor::Md5, "client-secret", rappor::HmacDrbg,
+                            *irr_rand);
+    params = new rappor::Params(64,    // num_bits (k)
+                                2,     // num_hashes (h)
+                                128,   // num_cohorts (m)
+                                0.25,  // probability f for PRR
+                                0.75,  // probability p for IRR
+                                0.5);  // probability q for IRR
+    encoder = new rappor::Encoder(encoder_id, *params, *deps);
+  }
+};
+
+
+///// EncoderUint32Test
+TEST_F(EncoderUint32Test, EncodeStringUint32) {
+  ASSERT_TRUE(encoder->EncodeString("foo", &bits_out));
+  ASSERT_EQ(2281639167, bits_out);
+  ASSERT_EQ(3, encoder->cohort());
+}
+
+TEST_F(EncoderUint32Test, EncodeStringUint32Cohort) {
+  encoder->set_cohort(4);  // Set pre-selected cohort.
+  ASSERT_TRUE(encoder->EncodeString("foo", &bits_out));
+  ASSERT_EQ(2281637247, bits_out);
+  ASSERT_EQ(4, encoder->cohort());
+}
+
+TEST_F(EncoderUint32Test, EncodeBitsUint32) {
+  ASSERT_TRUE(encoder->EncodeBits(0x123, &bits_out));
+  ASSERT_EQ(2784956095, bits_out);
+  ASSERT_EQ(3, encoder->cohort());
+}
+
+// Negative tests
+// num_cohorts is negative.
+TEST_F(EncoderUint32Test, NumCohortsMustBePositive) {
+  delete params;
+  params = new rappor::Params(32,    // num_bits (k)
+                              2,     // num_hashes (h)
+                              -1,   // num_cohorts (m)
+                              0.25,  // probability f for PRR
+                              0.75,  // probability p for IRR
+                              0.5);  // probability q for IRR
+  ASSERT_THROW(rappor::Encoder(encoder_id, *params, *deps),
+               std::out_of_range);
+}
+
+// num_bits 64 when only 32 bits are possible.
+TEST_F(EncoderUint32Test, Sha256NoMoreThan32Bits) {
+  delete params;
+  params = new rappor::Params(64,    // num_bits (k)
+                              2,     // num_hashes (h)
+                              128,   // num_cohorts (m)
+                              0.25,  // probability f for PRR
+                              0.75,  // probability p for IRR
+                              0.5);  // probability q for IRR
+  ASSERT_THROW(rappor::Encoder(encoder_id, *params, *deps),
+               std::out_of_range);
+}
+
+// num_hashes too high.
+TEST_F(EncoderUint32Test, NumHashesNoMoreThan16) {
+  delete params;
+  params = new rappor::Params(32,    // num_bits (k)
+                              17,     // num_hashes (h)
+                              128,   // num_cohorts (m)
+                              0.25,  // probability f for PRR
+                              0.75,  // probability p for IRR
+                              0.5);  // probability q for IRR
+  ASSERT_THROW(rappor::Encoder(encoder_id, *params, *deps),
+               std::out_of_range);
+}
+
+// EncoderString with 4-byte vector and HMACSHA256 and
+// EncoderString with Uint32 and HMACSHA256 should match.
+TEST_F(EncoderUint32Test, StringUint32AndStringVectorMatch) {
+  ASSERT_TRUE(encoder->EncodeString("foo", &bits_out));
+  ASSERT_EQ(2281639167, bits_out);
+  std::vector<uint8_t> expected_out(4);
+  expected_out[0] = (bits_out & 0xFF000000) >> 24;
+  expected_out[1] = (bits_out & 0x00FF0000) >> 16;
+  expected_out[2] = (bits_out & 0x0000FF00) >> 8;
+  expected_out[3] = bits_out  & 0x000000FF;
+
+  // Reset the mock randomizer.
+  delete irr_rand;
+  delete deps;
+  delete encoder;
+  fclose(fp);
+  fp = mock_urandom();
+  irr_rand = new rappor::UnixKernelRand(fp);
+  deps = new rappor::Deps(rappor::Md5, "client-secret", rappor::HmacSha256,
+                          *irr_rand);
+  encoder = new rappor::Encoder(encoder_id, *params, *deps);
+  ASSERT_TRUE(encoder->EncodeString("foo", &bits_vector));
+  ASSERT_EQ(expected_out, bits_vector);
+}
+
+///// EncoderUnlimTest
+
+TEST_F(EncoderUnlimTest, EncodeStringUint64) {
+  static const uint8_t ex[] = { 134, 255, 11, 255, 252, 119, 240, 223 };
+  std::vector<uint8_t> expected_vector(ex, ex + sizeof(ex));
+
+  ASSERT_TRUE(encoder->EncodeString("foo", &bits_vector));
+  ASSERT_EQ(expected_vector, bits_vector);
+  ASSERT_EQ(93, encoder->cohort());
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/client/cpp/openssl_hash_impl.cc
+++ b/client/cpp/openssl_hash_impl.cc
@@ -59,7 +59,11 @@ bool HmacDrbg(const std::string& key, const std::string& value,
   };
   std::string v;
   std::vector<uint8_t> temp_output;
-  const int num_bytes = output->size();
+  int num_bytes = output->size();
+  if (num_bytes == 0) {
+    // By default return 32 bytes for Uint32 applications.
+    num_bytes = 32;
+  }
 
   v.append(32u, 0x01);
   temp_output.resize(32, 0);


### PR DESCRIPTION
* Added second EncodeString prototype using vector<uint8_t> for >32 bit strings (byte-aligned)
* Added second MakeBloomFilter protoype using vector<uint8_t> for >32 bit strings
* Converted rappor::Encode to throw exceptions instead of using assert()
* Wrote unit tests, including one to ensure that old and new EncodeString work equivalently
* Still throw errors if attempting to use HmacSha256 with >32 bits