### PR TITLE
Fixing breakages in rappor-sim Shiny app

### DIFF
--- a/analysis/R/decode.R
+++ b/analysis/R/decode.R
@@ -469,7 +469,9 @@ Decode <- function(counts, map, params, alpha = 0.05,
 
   list(fit = fit, summary = res_summary, privacy = privacy, params = params,
        lasso = NULL, residual = as.vector(residual),
-       counts = counts[, -1], resid = NULL, metrics = metrics)
+       counts = counts[, -1], resid = NULL, metrics = metrics,
+       ests = es$estimates  # ests needed by Shiny rappor-sim app      
+  )
 }
 
 ComputeCounts <- function(reports, cohorts, params) {

--- a/analysis/R/simulation.R
+++ b/analysis/R/simulation.R
@@ -259,7 +259,7 @@ GenerateSamples <- function(N = 10^5, params, pop_params, alpha = .05,
   fit$fit$Truth <- table(samp)[fit$fit$string]
   fit$fit$Truth[is.na(fit$fit$Truth)] <- 0
 
-  fit$map <- map$map
+  fit$map <- map$map_by_cohort
   fit$truth <- truth
   fit$strs <- strs
   fit$probs <- probs

--- a/apps/rappor-sim/run_app.sh
+++ b/apps/rappor-sim/run_app.sh
@@ -8,5 +8,8 @@
 app_dir=$(dirname $0)
 port=${1:-6788}
 
+# Needed by source.rappor in analysis/R/*.R
+export RAPPOR_REPO=../../
+
 # host= makes it serve to other machines, not just localhost.
 exec R --vanilla --slave -e "shiny::runApp('$app_dir', host='0.0.0.0', port=$port)"

--- a/apps/rappor-sim/server.R
+++ b/apps/rappor-sim/server.R
@@ -103,7 +103,7 @@ shinyServer(function(input, output) {
   })
 
   output$resid <- renderPlot({
-    resid <- Sample()$resid
+    resid <- Sample()$residual
     params <- Params()
     plot(resid, xlab = "Bloom filter bits", ylab = "Residuals")
     abline(h = c(-1.96, 1.96), lty = 2, col = 2)

--- a/apps/rappor-sim/ui.R
+++ b/apps/rappor-sim/ui.R
@@ -85,7 +85,7 @@ shinyUI(pageWithSidebar(
                                               tabPanel("True Bits", plotOutput("truth", height = "800px")),
                                               tabPanel("Estimated Bits", plotOutput("ests", height = "800px")),
                                               tabPanel("Estimates vs Truth", plotOutput("ests_truth", height = "600px")),
-                                              tabPanel("Lasso", plotOutput("lasso", height = "600px")),
+                                              # tabPanel("Lasso", plotOutput("lasso", height = "600px")),
                                               tabPanel("Residuals", plotOutput("resid", height = "600px"))
                                               )
                                   )


### PR DESCRIPTION
- Decode() must return ests
- map$map deprecated --> replace with map$map_by_cohort
- resid --> residual to display residuals
- run_app.sh requires RAPPOR_REPO env. variable
- disabling LASSO tab in simulation (for now)